### PR TITLE
fix(examples): prevent play vars from overriding inventory variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ target node automatically. The `helm-diff` plugin enables true
 idempotency — repeated runs report no changes when the release is
 already up to date.
 
+### Customizing variables
+
+The example prepare playbooks define internal variables (like
+`cozystack_k3s_server_args`) in the play `vars` section. User-facing
+variables such as `cozystack_k3s_extra_args` and
+`cozystack_flush_iptables` should be set **in the inventory**, not in
+the playbook. Ansible play `vars` take precedence over inventory
+variables, so defining them in both places causes the inventory values
+to be silently ignored.
+
 ### Idempotency
 
 All tasks are idempotent. Running the playbook multiple times produces no changes if the state is already correct. The `--check` mode is supported.

--- a/examples/rhel/prepare-rhel.yml
+++ b/examples/rhel/prepare-rhel.yml
@@ -26,11 +26,6 @@
       - { name: net.ipv4.conf.all.forwarding, value: "1" }
       - { name: vm.swappiness, value: "1" }
 
-    # Set to true on providers with restrictive iptables rules (OCI, etc.)
-    # WARNING: This flushes live iptables rules only (not persistent).
-    # Also stops firewalld to prevent rule restoration.
-    cozystack_flush_iptables: false
-
     # k3s server arguments required by Cozystack.
     # These disable built-in components that Cozystack replaces.
     cozystack_k3s_server_args: >-
@@ -43,10 +38,6 @@
       --flannel-backend=none
       --cluster-domain=cozy.local
       --kubelet-arg=max-pods=220
-
-    # Additional k3s server arguments (user-provided).
-    # Use for environment-specific flags like --tls-san.
-    cozystack_k3s_extra_args: ""
 
     # k3s server config YAML (CIDRs).
     cozystack_k3s_server_config_yaml: |
@@ -62,7 +53,7 @@
       ansible.builtin.set_fact:
         extra_server_args: >-
           {{ cozystack_k3s_server_args }}
-          {{ cozystack_k3s_extra_args }}
+          {{ cozystack_k3s_extra_args | default("") }}
       when: extra_server_args is not defined
 
     - name: Set k3s server config for Cozystack
@@ -90,20 +81,20 @@
         name: firewalld
         enabled: false
         state: stopped
-      when: cozystack_flush_iptables
+      when: cozystack_flush_iptables | default(false)
       failed_when: false
 
     - name: Flush iptables INPUT chain
       ansible.builtin.iptables:
         chain: INPUT
         flush: true
-      when: cozystack_flush_iptables
+      when: cozystack_flush_iptables | default(false)
 
     - name: Set iptables INPUT policy to ACCEPT
       ansible.builtin.iptables:
         chain: INPUT
         policy: ACCEPT
-      when: cozystack_flush_iptables
+      when: cozystack_flush_iptables | default(false)
 
     - name: Enable iscsid service
       ansible.builtin.systemd:

--- a/examples/suse/prepare-suse.yml
+++ b/examples/suse/prepare-suse.yml
@@ -29,11 +29,6 @@
       - { name: net.ipv4.conf.all.forwarding, value: "1" }
       - { name: vm.swappiness, value: "1" }
 
-    # Set to true on providers with restrictive iptables rules (OCI, etc.)
-    # WARNING: This flushes live iptables rules only (not persistent).
-    # Also stops firewalld to prevent rule restoration.
-    cozystack_flush_iptables: false
-
     # k3s server arguments required by Cozystack.
     # These disable built-in components that Cozystack replaces.
     cozystack_k3s_server_args: >-
@@ -46,10 +41,6 @@
       --flannel-backend=none
       --cluster-domain=cozy.local
       --kubelet-arg=max-pods=220
-
-    # Additional k3s server arguments (user-provided).
-    # Use for environment-specific flags like --tls-san.
-    cozystack_k3s_extra_args: ""
 
     # k3s server config YAML (CIDRs).
     cozystack_k3s_server_config_yaml: |
@@ -65,7 +56,7 @@
       ansible.builtin.set_fact:
         extra_server_args: >-
           {{ cozystack_k3s_server_args }}
-          {{ cozystack_k3s_extra_args }}
+          {{ cozystack_k3s_extra_args | default("") }}
       when: extra_server_args is not defined
 
     - name: Set k3s server config for Cozystack
@@ -93,20 +84,20 @@
         name: firewalld
         enabled: false
         state: stopped
-      when: cozystack_flush_iptables
+      when: cozystack_flush_iptables | default(false)
       failed_when: false
 
     - name: Flush iptables INPUT chain
       ansible.builtin.iptables:
         chain: INPUT
         flush: true
-      when: cozystack_flush_iptables
+      when: cozystack_flush_iptables | default(false)
 
     - name: Set iptables INPUT policy to ACCEPT
       ansible.builtin.iptables:
         chain: INPUT
         policy: ACCEPT
-      when: cozystack_flush_iptables
+      when: cozystack_flush_iptables | default(false)
 
     - name: Enable iscsid service
       ansible.builtin.systemd:

--- a/examples/ubuntu/prepare-ubuntu.yml
+++ b/examples/ubuntu/prepare-ubuntu.yml
@@ -28,11 +28,6 @@
       - { name: net.ipv4.conf.all.forwarding, value: "1" }
       - { name: vm.swappiness, value: "1" }
 
-    # Set to true on providers with restrictive iptables rules (OCI, etc.)
-    # WARNING: This flushes live iptables rules only (not persistent).
-    # Also stops ufw to prevent rule restoration.
-    cozystack_flush_iptables: false
-
     # k3s server arguments required by Cozystack.
     # These disable built-in components that Cozystack replaces.
     cozystack_k3s_server_args: >-
@@ -45,10 +40,6 @@
       --flannel-backend=none
       --cluster-domain=cozy.local
       --kubelet-arg=max-pods=220
-
-    # Additional k3s server arguments (user-provided).
-    # Use for environment-specific flags like --tls-san.
-    cozystack_k3s_extra_args: ""
 
     # k3s server config YAML (CIDRs).
     cozystack_k3s_server_config_yaml: |
@@ -64,7 +55,7 @@
       ansible.builtin.set_fact:
         extra_server_args: >-
           {{ cozystack_k3s_server_args }}
-          {{ cozystack_k3s_extra_args }}
+          {{ cozystack_k3s_extra_args | default("") }}
       when: extra_server_args is not defined
 
     - name: Set k3s server config for Cozystack
@@ -92,20 +83,20 @@
         name: ufw
         enabled: false
         state: stopped
-      when: cozystack_flush_iptables
+      when: cozystack_flush_iptables | default(false)
       failed_when: false
 
     - name: Flush iptables INPUT chain
       ansible.builtin.iptables:
         chain: INPUT
         flush: true
-      when: cozystack_flush_iptables
+      when: cozystack_flush_iptables | default(false)
 
     - name: Set iptables INPUT policy to ACCEPT
       ansible.builtin.iptables:
         chain: INPUT
         policy: ACCEPT
-      when: cozystack_flush_iptables
+      when: cozystack_flush_iptables | default(false)
 
     - name: Enable iscsid service
       ansible.builtin.systemd:


### PR DESCRIPTION
## Summary

- Remove `cozystack_k3s_extra_args` and `cozystack_flush_iptables` from play `vars` in all three prepare playbooks (ubuntu, rhel, suse)
- Use `| default("")` and `| default(false)` for safe fallbacks when variables are not set
- Add a note to README about variable customization and Ansible precedence

## Problem

Ansible play `vars` have higher precedence than inventory variables. When `cozystack_k3s_extra_args: ""` was defined in the play `vars` section, any value set in the inventory (e.g., `--tls-san=<public_ip>`) was silently ignored. This caused k3s to generate TLS certificates without the user-specified SANs.

## Test plan

- [ ] Verify `cozystack_k3s_extra_args` from inventory is applied to k3s service args
- [ ] Verify `cozystack_flush_iptables: true` from inventory triggers iptables flush
- [ ] Verify playbooks work without these variables set (defaults kick in)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guidance on configuring variables in the inventory rather than playbooks, including variable precedence rules to prevent silent failures.

* **Improvements**
  * Enhanced playbook resilience by adding default values for optional configuration variables, gracefully handling cases where they are undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->