### PR TITLE
chore: bump cozystack to v1.1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 cozystack.installer Release Notes
 ============================
 
+v1.1.2
+======
+
+Synced with Cozystack v1.1.2.
+
+- Bump ``cozystack_chart_version`` to ``1.1.2``
+
 v1.0.2
 ======
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Runs on `server[0]` only.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `cozystack_chart_ref` | `oci://ghcr.io/cozystack/cozystack/cozy-installer` | Helm chart OCI reference |
-| `cozystack_chart_version` | `1.0.2` | Helm chart version |
+| `cozystack_chart_version` | `1.1.2` | Helm chart version |
 | `cozystack_release_name` | `cozy-installer` | Helm release name |
 | `cozystack_namespace` | `cozy-system` | Namespace for operator and resources |
 | `cozystack_release_namespace` | `kube-system` | Namespace for Helm release secret |

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cozystack
 name: installer
-version: 1.0.2
+version: 1.1.2
 readme: README.md
 authors:
   - Aleksei Sviridkin <f@lex.la>

--- a/roles/cozystack/defaults/main.yml
+++ b/roles/cozystack/defaults/main.yml
@@ -10,7 +10,7 @@
 cozystack_chart_ref: "oci://ghcr.io/cozystack/cozystack/cozy-installer"
 
 # Helm chart version (synced with Cozystack release)
-cozystack_chart_version: "1.0.2"
+cozystack_chart_version: "1.1.2"
 
 # Helm release name
 cozystack_release_name: "cozy-installer"


### PR DESCRIPTION
## Summary

- Bump `cozystack_chart_version` from `1.0.2` to `1.1.2`
- Update collection version in `galaxy.yml` to match

## Test plan

- [ ] Deploy Cozystack on a test cluster using the updated chart version
- [ ] Verify all packages reconcile successfully