### PR TITLE
feat(ci): add Renovate, release workflow, and self-contained examples

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,4 @@
 ---
-# Prevent ansible-lint from auto-installing requirements.yml
-# (git commit hash versions crash ansible-galaxy's LooseVersion parser).
 # CI installs dependencies in a separate step before running lint.
 offline: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+---
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - galaxy.yml
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get version from galaxy.yml
+        id: version
+        run: |
+          VERSION=$(grep '^version:' galaxy.yml | awk '{print $2}')
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "v${{ steps.version.outputs.version }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --generate-notes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,9 @@ jobs:
           ansible-galaxy collection install cozystack-installer-*.tar.gz --force
 
       - name: Install collection dependencies
-        run: ansible-galaxy collection install --requirements-file requirements.yml
+        run: |
+          ansible-galaxy collection install --requirements-file requirements.yml
+          ansible-galaxy collection install --requirements-file tests/requirements.yml
 
       - name: Run full pipeline
         run: >-

--- a/examples/rhel/requirements.yml
+++ b/examples/rhel/requirements.yml
@@ -1,0 +1,14 @@
+---
+collections:
+  - name: ansible.posix
+  - name: community.general
+  - name: kubernetes.core
+  - name: k3s.orchestration
+    source: https://github.com/k3s-io/k3s-ansible.git
+    type: git
+    version: 1.1.0
+  - name: cozystack.installer
+    source: https://github.com/cozystack/ansible-cozystack.git
+    type: git
+    # WARNING: never use 'main' in production — always pin to a release tag (e.g. v1.1.2)
+    version: main

--- a/examples/rhel/requirements.yml
+++ b/examples/rhel/requirements.yml
@@ -10,5 +10,4 @@ collections:
   - name: cozystack.installer
     source: https://github.com/cozystack/ansible-cozystack.git
     type: git
-    # WARNING: never use 'main' in production — always pin to a release tag (e.g. v1.1.2)
-    version: main
+    version: 1.1.0

--- a/examples/rhel/site.yml
+++ b/examples/rhel/site.yml
@@ -2,7 +2,7 @@
 # Full pipeline: prepare RHEL/CentOS nodes + deploy k3s + install Cozystack
 #
 # Prerequisites:
-#   ansible-galaxy collection install --requirements-file ../../requirements.yml
+#   ansible-galaxy collection install --requirements-file requirements.yml
 #
 # Usage:
 #   ansible-playbook site.yml

--- a/examples/suse/requirements.yml
+++ b/examples/suse/requirements.yml
@@ -1,0 +1,14 @@
+---
+collections:
+  - name: ansible.posix
+  - name: community.general
+  - name: kubernetes.core
+  - name: k3s.orchestration
+    source: https://github.com/k3s-io/k3s-ansible.git
+    type: git
+    version: 1.1.0
+  - name: cozystack.installer
+    source: https://github.com/cozystack/ansible-cozystack.git
+    type: git
+    # WARNING: never use 'main' in production — always pin to a release tag (e.g. v1.1.2)
+    version: main

--- a/examples/suse/requirements.yml
+++ b/examples/suse/requirements.yml
@@ -10,5 +10,4 @@ collections:
   - name: cozystack.installer
     source: https://github.com/cozystack/ansible-cozystack.git
     type: git
-    # WARNING: never use 'main' in production — always pin to a release tag (e.g. v1.1.2)
-    version: main
+    version: 1.1.0

--- a/examples/suse/site.yml
+++ b/examples/suse/site.yml
@@ -2,7 +2,7 @@
 # Full pipeline: prepare openSUSE/SLE nodes + deploy k3s + install Cozystack
 #
 # Prerequisites:
-#   ansible-galaxy collection install --requirements-file ../../requirements.yml
+#   ansible-galaxy collection install --requirements-file requirements.yml
 #
 # Usage:
 #   ansible-playbook site.yml

--- a/examples/ubuntu/requirements.yml
+++ b/examples/ubuntu/requirements.yml
@@ -1,0 +1,14 @@
+---
+collections:
+  - name: ansible.posix
+  - name: community.general
+  - name: kubernetes.core
+  - name: k3s.orchestration
+    source: https://github.com/k3s-io/k3s-ansible.git
+    type: git
+    version: 1.1.0
+  - name: cozystack.installer
+    source: https://github.com/cozystack/ansible-cozystack.git
+    type: git
+    # WARNING: never use 'main' in production — always pin to a release tag (e.g. v1.1.2)
+    version: main

--- a/examples/ubuntu/requirements.yml
+++ b/examples/ubuntu/requirements.yml
@@ -10,5 +10,4 @@ collections:
   - name: cozystack.installer
     source: https://github.com/cozystack/ansible-cozystack.git
     type: git
-    # WARNING: never use 'main' in production — always pin to a release tag (e.g. v1.1.2)
-    version: main
+    version: 1.1.0

--- a/examples/ubuntu/site.yml
+++ b/examples/ubuntu/site.yml
@@ -2,7 +2,7 @@
 # Full pipeline: prepare Ubuntu/Debian nodes + deploy k3s + install Cozystack
 #
 # Prerequisites:
-#   ansible-galaxy collection install --requirements-file ../../requirements.yml
+#   ansible-galaxy collection install --requirements-file requirements.yml
 #
 # Usage:
 #   ansible-playbook site.yml

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cozystack
 name: installer
-version: 1.1.2
+version: 1.1.0
 readme: README.md
 authors:
   - Aleksei Sviridkin <f@lex.la>

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**"
+  ],
+  "platformAutomerge": true,
+  "automerge": true,
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/roles/cozystack/defaults/main\\.yml$/"],
+      "matchStrings": [
+        "cozystack_chart_version:\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "ghcr.io/cozystack/cozystack/cozy-installer",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^galaxy\\.yml$/"],
+      "matchStrings": [
+        "version:\\s*(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "ghcr.io/cozystack/cozystack/cozy-installer",
+      "datasourceTemplate": "docker"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,22 @@
       ],
       "depNameTemplate": "ghcr.io/cozystack/cozystack/cozy-installer",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)requirements\\.yml$/"],
+      "matchStrings": [
+        "source:\\s*https://github\\.com/cozystack/ansible-cozystack\\.git\\s+type:\\s*git\\s+version:\\s*(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "ghcr.io/cozystack/cozystack/cozy-installer",
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["ansible-galaxy"],
+      "matchPackageNames": ["cozystack.installer"],
+      "enabled": false
     }
   ]
 }

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,3 @@ collections:
   - name: ansible.posix
   - name: community.general
   - name: kubernetes.core
-  - name: k3s.orchestration
-    source: https://github.com/k3s-io/k3s-ansible.git
-    type: git
-    version: 77b49f76ce744fa265088e95e9a49a57a6675a54

--- a/roles/cozystack/defaults/main.yml
+++ b/roles/cozystack/defaults/main.yml
@@ -10,7 +10,7 @@
 cozystack_chart_ref: "oci://ghcr.io/cozystack/cozystack/cozy-installer"
 
 # Helm chart version (synced with Cozystack release)
-cozystack_chart_version: "1.1.2"
+cozystack_chart_version: "1.1.0"
 
 # Helm release name
 cozystack_release_name: "cozy-installer"

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,8 @@
+---
+# Dependencies for running example playbooks in CI.
+# Not required by the collection itself.
+collections:
+  - name: k3s.orchestration
+    source: https://github.com/k3s-io/k3s-ansible.git
+    type: git
+    version: 1.1.0


### PR DESCRIPTION
## Summary

- Add Renovate config with automerge (squash strategy) to track Cozystack chart versions and k3s-ansible releases
- Add GitHub Actions release workflow that creates a release when `galaxy.yml` version changes on main
- Move `k3s.orchestration` from root `requirements.yml` to `tests/requirements.yml` (CI-only dependency)
- Add self-contained `requirements.yml` to each example directory with all dependencies listed explicitly
- Downgrade cozystack to 1.1.0 to validate Renovate detects the upgrade to 1.1.2

## Test plan

- [x] `renovate-config-validator` passes
- [x] Local `renovate --platform=local` confirms detection of cozystack 1.1.0→1.1.2 and k3s-ansible 1.1.0→1.2.0
- [ ] CI passes (lint, sanity, e2e)
- [ ] After merge, Renovate creates PR to bump cozystack to 1.1.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated release workflow.
  * Added Renovate-based dependency automation.

* **Updates**
  * Version set to 1.1.0.
  * Example environments now use per-OS dependency manifests and simplified example playbooks.
  * Test workflow now installs additional test-specific dependencies.
  * Default chart version aligned to 1.1.0.

* **Chores**
  * Cleaned up configuration comments and manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->