### PR TITLE
fix(kubeovn): derive MASTER_NODES from server group for multi-master support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,16 @@ jobs:
           ansible-playbook tests/test-master-nodes.yml
           --inventory tests/ci-inventory.yml
 
+      - name: Test hostname host keys are rejected
+        run: |
+          if ansible-playbook tests/test-master-nodes.yml \
+            --inventory tests/test-hostname-inventory.yml 2>&1; then
+            echo "ERROR: Expected failure for hostname host keys, but playbook succeeded"
+            exit 1
+          else
+            echo "OK: Hostname host keys correctly rejected"
+          fi
+
   e2e:
     name: E2E
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,31 @@ jobs:
         working-directory: ansible_collections/cozystack/installer
         run: ansible-test sanity --color
 
+  master-nodes:
+    name: Multi-master MASTER_NODES
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install Ansible
+        run: pip install ansible-core
+
+      - name: Test auto-detection from server group (3 nodes)
+        run: >-
+          ansible-playbook tests/test-master-nodes.yml
+          --inventory tests/test-multi-master-inventory.yml
+
+      - name: Test single-node inventory
+        run: >-
+          ansible-playbook tests/test-master-nodes.yml
+          --inventory tests/ci-inventory.yml
+
   e2e:
     name: E2E
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,8 +119,8 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install Ansible
-        run: pip install ansible-core
+      - name: Install Ansible and dependencies
+        run: pip install ansible-core netaddr
 
       - name: Build and install collection
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,15 +76,23 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install Ansible
-        run: pip install ansible-core
+      - name: Install Ansible and dependencies
+        run: pip install ansible-core netaddr
+
+      - name: Install required collections
+        run: ansible-galaxy collection install ansible.utils
 
       - name: Test auto-detection from server group (3 nodes)
         run: >-
           ansible-playbook tests/test-master-nodes.yml
           --inventory tests/test-multi-master-inventory.yml
 
-      - name: Test single-node inventory
+      - name: Test single-node auto-detection (IP host key)
+        run: >-
+          ansible-playbook tests/test-master-nodes.yml
+          --inventory tests/test-single-master-inventory.yml
+
+      - name: Test single-node explicit override (CI inventory)
         run: >-
           ansible-playbook tests/test-master-nodes.yml
           --inventory tests/ci-inventory.yml

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Runs on `server[0]` only.
 | `cozystack_pod_gateway` | `10.42.0.1` | Pod gateway |
 | `cozystack_svc_cidr` | `10.43.0.0/16` | Service CIDR |
 | `cozystack_join_cidr` | `100.64.0.0/16` | Join CIDR |
+| `cozystack_master_nodes` | `""` (auto-detect) | Comma-separated control-plane node IPs for kube-ovn RAFT. Empty = auto-detect from `server` group |
 | `cozystack_operator_wait_timeout` | `300` | Timeout for operator/CRD readiness (seconds) |
 
 ## Using with k3s
@@ -228,6 +229,31 @@ or `examples/suse/`:
 ### apiServerHost must be the internal IP
 
 On cloud providers with NAT (OCI, AWS, GCP), nodes have internal IPs different from public IPs. KubeOVN validates the host IP against `NODE_IPS` and crashes if they don't match. Always use the IP visible on the node's network interface.
+
+### Multi-master setup (kube-ovn RAFT)
+
+Kube-ovn requires `MASTER_NODES` — a comma-separated list of all
+control-plane node IPs for OVN RAFT consensus. By default, the role
+auto-detects these IPs from the `server` inventory group host keys.
+
+This works when host keys are internal IPs (the recommended inventory
+pattern):
+
+```yaml
+server:
+  hosts:
+    10.0.0.10:
+      ansible_host: 203.0.113.10
+    10.0.0.11:
+      ansible_host: 203.0.113.11
+```
+
+If your inventory uses hostnames or non-IP host keys, set
+`cozystack_master_nodes` explicitly:
+
+```yaml
+cozystack_master_nodes: "10.0.0.10,10.0.0.11,10.0.0.12"
+```
 
 ### Automatic Helm installation
 

--- a/examples/ubuntu/inventory.yml
+++ b/examples/ubuntu/inventory.yml
@@ -3,15 +3,18 @@ cluster:
   children:
     server:
       hosts:
-        # Internal IP as host key, public IP as ansible_host
+        # Internal IP as host key, public IP as ansible_host.
+        # All server host keys are auto-collected as kube-ovn MASTER_NODES.
         10.0.0.10:
           ansible_host: 203.0.113.10
-    agent:
-      hosts:
         10.0.0.11:
           ansible_host: 203.0.113.11
         10.0.0.12:
           ansible_host: 203.0.113.12
+    agent:
+      hosts:
+        10.0.0.20:
+          ansible_host: 203.0.113.20
 
   vars:
     ansible_port: 22
@@ -25,6 +28,10 @@ cluster:
 
     # Cozystack configuration (REQUIRED)
     cozystack_api_server_host: "10.0.0.10"
+
+    # kube-ovn master nodes (auto-detected from 'server' group host keys).
+    # Override only if host keys are not internal IPs.
+    # cozystack_master_nodes: "10.0.0.10,10.0.0.11,10.0.0.12"
 
     # Platform Package configuration
     cozystack_root_host: "cozy.example.com"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,6 +16,7 @@ homepage: https://cozystack.io
 documentation: https://cozystack.io/docs
 dependencies:
   ansible.posix: ">=1.0.0"
+  ansible.utils: ">=2.0.0"
   kubernetes.core: ">=5.0.0"
 tags:
   - infrastructure

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,6 @@
 ---
 collections:
   - name: ansible.posix
+  - name: ansible.utils
   - name: community.general
   - name: kubernetes.core

--- a/roles/cozystack/defaults/main.yml
+++ b/roles/cozystack/defaults/main.yml
@@ -53,6 +53,10 @@ cozystack_platform_variant: "isp-full-generic"
 # Leave empty to skip publishing config in the Platform Package
 cozystack_root_host: ""
 
+# Comma-separated control-plane node IPs for kube-ovn RAFT consensus.
+# Empty = auto-detect from 'server' inventory group host keys.
+cozystack_master_nodes: ""
+
 # Network CIDRs for the Platform Package (defaults match k3s)
 cozystack_pod_cidr: "10.42.0.0/16"
 cozystack_pod_gateway: "10.42.0.1"

--- a/roles/cozystack/tasks/compute-master-nodes.yml
+++ b/roles/cozystack/tasks/compute-master-nodes.yml
@@ -1,0 +1,29 @@
+---
+# Compute and validate master node IPs for kube-ovn.
+# Included from main.yml and tests.
+- name: Compute master node IPs for kube-ovn
+  ansible.builtin.set_fact:
+    _cozystack_master_nodes: >-
+      {%- if cozystack_master_nodes | length > 0 -%}
+        {{ cozystack_master_nodes }}
+      {%- else -%}
+        {{ groups['server'] | join(',') }}
+      {%- endif -%}
+
+- name: Validate master node IPs are non-empty
+  ansible.builtin.assert:
+    that:
+      - _cozystack_master_nodes | length > 0
+    fail_msg: >-
+      Could not determine master node IPs for kube-ovn.
+      Set cozystack_master_nodes explicitly in your inventory.
+
+- name: Validate master node IPs are valid addresses
+  ansible.builtin.assert:
+    that:
+      - (item | ansible.utils.ipaddr) != false
+    fail_msg: >-
+      '{{ item }}' is not a valid IP address in MASTER_NODES.
+      Inventory host keys in the 'server' group must be IPs, not hostnames.
+      Alternatively, set cozystack_master_nodes explicitly.
+  loop: "{{ _cozystack_master_nodes.split(',') }}"

--- a/roles/cozystack/tasks/main.yml
+++ b/roles/cozystack/tasks/main.yml
@@ -9,23 +9,8 @@
       It must be the node's INTERNAL IP
       (visible on network interface, not public/NAT IP).
 
-- name: Compute master node IPs for kube-ovn
-  ansible.builtin.set_fact:
-    _cozystack_master_nodes: >-
-      {%- if cozystack_master_nodes | length > 0 -%}
-        {{ cozystack_master_nodes }}
-      {%- else -%}
-        {{ groups['server'] | join(',') }}
-      {%- endif -%}
-  when: cozystack_create_platform_package
-
-- name: Validate master node IPs
-  ansible.builtin.assert:
-    that:
-      - _cozystack_master_nodes | length > 0
-    fail_msg: >-
-      Could not determine master node IPs for kube-ovn.
-      Set cozystack_master_nodes explicitly in your inventory.
+- name: Compute and validate master node IPs for kube-ovn
+  ansible.builtin.include_tasks: compute-master-nodes.yml
   when: cozystack_create_platform_package
 
 - name: Set architecture for Helm download

--- a/roles/cozystack/tasks/main.yml
+++ b/roles/cozystack/tasks/main.yml
@@ -9,6 +9,25 @@
       It must be the node's INTERNAL IP
       (visible on network interface, not public/NAT IP).
 
+- name: Compute master node IPs for kube-ovn
+  ansible.builtin.set_fact:
+    _cozystack_master_nodes: >-
+      {%- if cozystack_master_nodes | length > 0 -%}
+        {{ cozystack_master_nodes }}
+      {%- else -%}
+        {{ groups['server'] | join(',') }}
+      {%- endif -%}
+  when: cozystack_create_platform_package
+
+- name: Validate master node IPs
+  ansible.builtin.assert:
+    that:
+      - _cozystack_master_nodes | length > 0
+    fail_msg: >-
+      Could not determine master node IPs for kube-ovn.
+      Set cozystack_master_nodes explicitly in your inventory.
+  when: cozystack_create_platform_package
+
 - name: Set architecture for Helm download
   ansible.builtin.set_fact:
     _cozystack_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}"

--- a/roles/cozystack/templates/platform-package.yml.j2
+++ b/roles/cozystack/templates/platform-package.yml.j2
@@ -16,7 +16,7 @@ spec:
             autoMount:
               enabled: true
         kube-ovn:
-          MASTER_NODES: {{ cozystack_api_server_host | to_json }}
+          MASTER_NODES: {{ _cozystack_master_nodes | to_json }}
     platform:
       values:
         networking:

--- a/tests/ci-inventory.yml
+++ b/tests/ci-inventory.yml
@@ -21,6 +21,7 @@ cluster:
 
     # Cozystack configuration
     cozystack_api_server_host: "127.0.0.1"
+    cozystack_master_nodes: "127.0.0.1"
     cozystack_root_host: "cozy.ci-test.local"
     cozystack_platform_variant: "isp-full-generic"
 

--- a/tests/test-hostname-inventory.yml
+++ b/tests/test-hostname-inventory.yml
@@ -1,0 +1,16 @@
+---
+# Inventory with hostname host keys (NOT IPs).
+# Used to verify that IP validation correctly rejects hostnames.
+cluster:
+  children:
+    server:
+      hosts:
+        node1.example.com:
+          ansible_connection: local
+          ansible_host: 127.0.0.1
+    agent:
+      hosts: {}
+
+  vars:
+    ansible_user: runner
+    cozystack_api_server_host: "10.0.0.1"

--- a/tests/test-master-nodes.yml
+++ b/tests/test-master-nodes.yml
@@ -1,0 +1,107 @@
+---
+# Verify that MASTER_NODES is correctly derived from the 'server'
+# inventory group in both single-master and multi-master setups.
+- name: Test MASTER_NODES computation and template rendering
+  hosts: server[0]
+  gather_facts: false
+  pre_tasks:
+    - name: Set template defaults when not defined by inventory
+      ansible.builtin.set_fact:
+        cozystack_master_nodes: "{{ cozystack_master_nodes | default('') }}"
+        cozystack_api_server_host: "{{ cozystack_api_server_host | default('127.0.0.1') }}"
+        cozystack_api_server_port: "{{ cozystack_api_server_port | default('6443') }}"
+        cozystack_namespace: "{{ cozystack_namespace | default('cozy-system') }}"
+        cozystack_platform_variant: "{{ cozystack_platform_variant | default('isp-full-generic') }}"
+        cozystack_root_host: "{{ cozystack_root_host | default('') }}"
+        cozystack_pod_cidr: "{{ cozystack_pod_cidr | default('10.42.0.0/16') }}"
+        cozystack_pod_gateway: "{{ cozystack_pod_gateway | default('10.42.0.1') }}"
+        cozystack_svc_cidr: "{{ cozystack_svc_cidr | default('10.43.0.0/16') }}"
+        cozystack_join_cidr: "{{ cozystack_join_cidr | default('100.64.0.0/16') }}"
+  tasks:
+    - name: Compute master node IPs for kube-ovn
+      ansible.builtin.set_fact:
+        _cozystack_master_nodes: >-
+          {%- if cozystack_master_nodes | length > 0 -%}
+            {{ cozystack_master_nodes }}
+          {%- else -%}
+            {{ groups['server'] | join(',') }}
+          {%- endif -%}
+
+    - name: Assert MASTER_NODES is non-empty
+      ansible.builtin.assert:
+        that:
+          - _cozystack_master_nodes | length > 0
+        fail_msg: "MASTER_NODES must not be empty, got '{{ _cozystack_master_nodes }}'."
+
+    - name: Assert auto-detected MASTER_NODES matches server group
+      ansible.builtin.assert:
+        that:
+          - >-
+            (_cozystack_master_nodes | split(',') | sort) ==
+            (groups['server'] | sort)
+        fail_msg: >-
+          Expected MASTER_NODES to match server group hosts.
+          Got '{{ _cozystack_master_nodes }}',
+          expected '{{ groups['server'] | join(',') }}'.
+      when: (cozystack_master_nodes | default('')) | length == 0
+
+    - name: Construct API server endpoint
+      ansible.builtin.set_fact:
+        _cozystack_api_endpoint: "https://{{ cozystack_api_server_host }}:{{ cozystack_api_server_port }}"
+
+    - name: Render Platform Package template
+      ansible.builtin.template:
+        src: "{{ playbook_dir }}/../roles/cozystack/templates/platform-package.yml.j2"
+        dest: /tmp/cozystack-test-platform-package.yml
+        mode: "0600"
+
+    - name: Read rendered manifest
+      ansible.builtin.slurp:
+        src: /tmp/cozystack-test-platform-package.yml
+      register: _rendered_manifest
+
+    - name: Assert rendered MASTER_NODES contains all server IPs
+      ansible.builtin.assert:
+        that:
+          - "'MASTER_NODES' in _rendered_content"
+          - "(_cozystack_master_nodes | to_json) in _rendered_content"
+        fail_msg: >-
+          Rendered template does not contain expected MASTER_NODES value.
+          Expected {{ _cozystack_master_nodes | to_json }} in output.
+      vars:
+        _rendered_content: "{{ _rendered_manifest.content | b64decode }}"
+
+    - name: Show rendered MASTER_NODES (debug)
+      ansible.builtin.debug:
+        msg: "MASTER_NODES = {{ _cozystack_master_nodes }}"
+
+    - name: Clean up test manifest
+      ansible.builtin.file:
+        path: /tmp/cozystack-test-platform-package.yml
+        state: absent
+      changed_when: false
+
+- name: Test explicit cozystack_master_nodes override
+  hosts: server[0]
+  gather_facts: false
+  tasks:
+    - name: Set explicit master nodes override
+      ansible.builtin.set_fact:
+        cozystack_master_nodes: "192.168.1.1,192.168.1.2"
+
+    - name: Compute master node IPs with explicit override
+      ansible.builtin.set_fact:
+        _cozystack_master_nodes: >-
+          {%- if cozystack_master_nodes | length > 0 -%}
+            {{ cozystack_master_nodes }}
+          {%- else -%}
+            {{ groups['server'] | join(',') }}
+          {%- endif -%}
+
+    - name: Assert explicit override is used
+      ansible.builtin.assert:
+        that:
+          - _cozystack_master_nodes == "192.168.1.1,192.168.1.2"
+        fail_msg: >-
+          Expected explicit override '192.168.1.1,192.168.1.2',
+          got '{{ _cozystack_master_nodes }}'.

--- a/tests/test-master-nodes.yml
+++ b/tests/test-master-nodes.yml
@@ -1,7 +1,8 @@
 ---
 # Verify that MASTER_NODES is correctly derived from the 'server'
 # inventory group in both single-master and multi-master setups.
-- name: Test MASTER_NODES computation and template rendering
+# Uses the actual role tasks (no duplicated Jinja2 logic).
+- name: Test MASTER_NODES auto-detection and template rendering
   hosts: server[0]
   gather_facts: false
   pre_tasks:
@@ -18,20 +19,9 @@
         cozystack_svc_cidr: "{{ cozystack_svc_cidr | default('10.43.0.0/16') }}"
         cozystack_join_cidr: "{{ cozystack_join_cidr | default('100.64.0.0/16') }}"
   tasks:
-    - name: Compute master node IPs for kube-ovn
-      ansible.builtin.set_fact:
-        _cozystack_master_nodes: >-
-          {%- if cozystack_master_nodes | length > 0 -%}
-            {{ cozystack_master_nodes }}
-          {%- else -%}
-            {{ groups['server'] | join(',') }}
-          {%- endif -%}
-
-    - name: Assert MASTER_NODES is non-empty
-      ansible.builtin.assert:
-        that:
-          - _cozystack_master_nodes | length > 0
-        fail_msg: "MASTER_NODES must not be empty, got '{{ _cozystack_master_nodes }}'."
+    - name: Include role master-node computation
+      ansible.builtin.include_tasks:
+        file: "{{ playbook_dir }}/../roles/cozystack/tasks/compute-master-nodes.yml"
 
     - name: Assert auto-detected MASTER_NODES matches server group
       ansible.builtin.assert:
@@ -89,14 +79,9 @@
       ansible.builtin.set_fact:
         cozystack_master_nodes: "192.168.1.1,192.168.1.2"
 
-    - name: Compute master node IPs with explicit override
-      ansible.builtin.set_fact:
-        _cozystack_master_nodes: >-
-          {%- if cozystack_master_nodes | length > 0 -%}
-            {{ cozystack_master_nodes }}
-          {%- else -%}
-            {{ groups['server'] | join(',') }}
-          {%- endif -%}
+    - name: Include role master-node computation
+      ansible.builtin.include_tasks:
+        file: "{{ playbook_dir }}/../roles/cozystack/tasks/compute-master-nodes.yml"
 
     - name: Assert explicit override is used
       ansible.builtin.assert:

--- a/tests/test-multi-master-inventory.yml
+++ b/tests/test-multi-master-inventory.yml
@@ -1,0 +1,33 @@
+---
+# Test inventory with three control-plane nodes.
+# Used to verify MASTER_NODES auto-detection from the 'server' group.
+cluster:
+  children:
+    server:
+      hosts:
+        10.0.0.10:
+          ansible_connection: local
+          ansible_host: 127.0.0.1
+        10.0.0.11:
+          ansible_connection: local
+          ansible_host: 127.0.0.1
+        10.0.0.12:
+          ansible_connection: local
+          ansible_host: 127.0.0.1
+    agent:
+      hosts: {}
+
+  vars:
+    ansible_user: runner
+
+    # Cozystack configuration
+    cozystack_api_server_host: "10.0.0.10"
+    cozystack_api_server_port: "6443"
+    cozystack_namespace: "cozy-system"
+    cozystack_platform_variant: "isp-full-generic"
+    cozystack_create_platform_package: true
+    cozystack_root_host: ""
+    cozystack_pod_cidr: "10.42.0.0/16"
+    cozystack_pod_gateway: "10.42.0.1"
+    cozystack_svc_cidr: "10.43.0.0/16"
+    cozystack_join_cidr: "100.64.0.0/16"

--- a/tests/test-single-master-inventory.yml
+++ b/tests/test-single-master-inventory.yml
@@ -1,0 +1,15 @@
+---
+# Single-master test inventory with IP as host key.
+# Tests auto-detection path (cozystack_master_nodes is NOT set).
+cluster:
+  children:
+    server:
+      hosts:
+        127.0.0.1:
+          ansible_connection: local
+    agent:
+      hosts: {}
+
+  vars:
+    ansible_user: runner
+    cozystack_api_server_host: "127.0.0.1"


### PR DESCRIPTION
## Summary

kube-ovn `MASTER_NODES` was hardcoded to `cozystack_api_server_host` — always a single IP. On multi-master clusters this breaks OVN RAFT consensus because `ovn-central` only gets one node in `NODE_IPS`.

The role now auto-detects all control-plane node IPs from the `server` inventory group, with an explicit `cozystack_master_nodes` override for non-standard inventories.

Ref: cozystack/cozystack#2242

## Changes

- Add `cozystack_master_nodes` variable (default: auto-detect from `server` group host keys)
- Compute `_cozystack_master_nodes` via `set_fact` with validation
- Update template to use computed value instead of single `cozystack_api_server_host`
- Set explicit `cozystack_master_nodes` in CI inventory (`localhost` host key is not an IP)
- Expand Ubuntu example to 3 control-plane nodes
- Document `cozystack_master_nodes` and multi-master setup in README
- Add CI job testing template rendering with both 3-node and single-node inventories

## Test plan

- [x] `ansible-lint` passes
- [x] `ansible-test sanity` passes (CI)
- [x] Tested on a live cluster: 3-node Colima VMs with bridged networking, k3s multi-master. Platform Package CR correctly rendered with `MASTER_NODES` containing all three control-plane IPs. `ovn-central` started without `host ip not in NODE_IPS` errors
- [x] Idempotency verified (pipeline EXIT: 0 on re-run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi‑master support with automatic master-node detection, explicit override option, and validation that host entries are IPs (hostname host keys rejected)

* **Documentation**
  * Added multi‑master setup docs and examples showing detection and explicit configuration

* **Tests**
  * New end‑to‑end tests covering auto‑detection, explicit override, IP validation, and manifest rendering
  * New CI job to run multi‑master validation in workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->