### PR TITLE
fix(cozystack): address CodeRabbit review, add Renovate k3s tracking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,13 +99,24 @@ jobs:
 
       - name: Test hostname host keys are rejected
         run: |
-          if ansible-playbook tests/test-master-nodes.yml \
-            --inventory tests/test-hostname-inventory.yml 2>&1; then
+          set +e
+          output="$(ansible-playbook tests/test-master-nodes.yml \
+            --inventory tests/test-hostname-inventory.yml 2>&1)"
+          status=$?
+          set -e
+
+          if [ "$status" -eq 0 ]; then
             echo "ERROR: Expected failure for hostname host keys, but playbook succeeded"
             exit 1
-          else
-            echo "OK: Hostname host keys correctly rejected"
           fi
+
+          if ! grep -q "not a valid IP address in MASTER_NODES" <<< "$output"; then
+            echo "ERROR: Playbook failed, but not due to hostname/IP validation"
+            echo "$output"
+            exit 1
+          fi
+
+          echo "OK: Hostname host keys correctly rejected"
 
   e2e:
     name: E2E

--- a/examples/rhel/inventory.yml
+++ b/examples/rhel/inventory.yml
@@ -18,6 +18,7 @@ cluster:
     ansible_user: cloud-user
 
     # k3s configuration (used by k3s.orchestration)
+    # renovate: datasource=github-releases depName=k3s-io/k3s
     k3s_version: v1.35.0+k3s3
     token: "CHANGE_ME"
     api_endpoint: "10.0.0.10"

--- a/examples/suse/inventory.yml
+++ b/examples/suse/inventory.yml
@@ -18,6 +18,7 @@ cluster:
     ansible_user: opensuse
 
     # k3s configuration (used by k3s.orchestration)
+    # renovate: datasource=github-releases depName=k3s-io/k3s
     k3s_version: v1.35.0+k3s3
     token: "CHANGE_ME"
     api_endpoint: "10.0.0.10"

--- a/examples/ubuntu/inventory.yml
+++ b/examples/ubuntu/inventory.yml
@@ -21,6 +21,7 @@ cluster:
     ansible_user: ubuntu
 
     # k3s configuration (used by k3s.orchestration)
+    # renovate: datasource=github-releases depName=k3s-io/k3s
     k3s_version: v1.35.0+k3s3
     token: "CHANGE_ME"
     api_endpoint: "10.0.0.10"

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/roles/cozystack/defaults/main\\.yml$/"],
+      "fileMatch": ["/roles/cozystack/defaults/main\\.yml$/"],
       "matchStrings": [
         "cozystack_chart_version:\\s*\"(?<currentValue>[^\"]+)\""
       ],
@@ -24,7 +24,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^galaxy\\.yml$/"],
+      "fileMatch": ["/^galaxy\\.yml$/"],
       "matchStrings": [
         "version:\\s*(?<currentValue>\\S+)"
       ],
@@ -33,12 +33,19 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/(^|/)requirements\\.yml$/"],
+      "fileMatch": ["/(^|/)requirements\\.yml$/"],
       "matchStrings": [
         "source:\\s*https://github\\.com/cozystack/ansible-cozystack\\.git\\s+type:\\s*git\\s+version:\\s*(?<currentValue>\\S+)"
       ],
       "depNameTemplate": "ghcr.io/cozystack/cozystack/cozy-installer",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["inventory\\.yml$", "ci-inventory\\.yml$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)[\\s\\S]*?k3s_version:\\s*(?<currentValue>[^\\s]+)"
+      ]
     }
   ],
   "packageRules": [

--- a/roles/cozystack/tasks/compute-master-nodes.yml
+++ b/roles/cozystack/tasks/compute-master-nodes.yml
@@ -7,7 +7,7 @@
       {%- if cozystack_master_nodes | length > 0 -%}
         {{ cozystack_master_nodes }}
       {%- else -%}
-        {{ groups['server'] | join(',') }}
+        {{ groups.get('server', []) | join(',') }}
       {%- endif -%}
 
 - name: Validate master node IPs are non-empty

--- a/tests/ci-inventory.yml
+++ b/tests/ci-inventory.yml
@@ -14,6 +14,7 @@ cluster:
     ansible_user: runner
 
     # k3s configuration
+    # renovate: datasource=github-releases depName=k3s-io/k3s
     k3s_version: v1.35.0+k3s3
     token: "ci-test-token"
     api_endpoint: "127.0.0.1"


### PR DESCRIPTION
## Summary

Follow-up to #12 addressing CodeRabbit review comments and adding Renovate tracking for k3s versions.

## Changes

- Guard `groups['server']` lookup with `groups.get('server', [])` to produce a clear assert error instead of a hard-fail when the group is absent
- Tighten negative hostname test to verify the specific IP validation error message, not just any playbook failure
- Add Renovate annotations (`# renovate: datasource=github-releases depName=k3s-io/k3s`) to all inventory files with `k3s_version`
- Add customManager regex rule to `renovate.json` for automatic k3s version tracking
- Fix pre-existing `managerFilePatterns` → `fileMatch` in all customManagers (Renovate 37 compatibility)

## Test plan

- [x] `ansible-lint` passes
- [x] All existing tests pass (multi-master, single-master, explicit override, hostname rejection)
- [x] Renovate `--platform=local` correctly detects k3s updates across all 4 inventory files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when server group configuration is missing from deployment setup

* **Chores**
  * Enhanced automated dependency tracking for k3s across example and test inventory files
  * Strengthened test validation workflow with more robust error detection and reporting
  * Updated dependency management configuration to improve version update tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->