### PR TITLE
fix(renovate): strip regex delimiters from fileMatch patterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["/roles/cozystack/defaults/main\\.yml$/"],
+      "fileMatch": ["roles/cozystack/defaults/main\\.yml$"],
       "matchStrings": [
         "cozystack_chart_version:\\s*\"(?<currentValue>[^\"]+)\""
       ],
@@ -24,7 +24,7 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["/^galaxy\\.yml$/"],
+      "fileMatch": ["^galaxy\\.yml$"],
       "matchStrings": [
         "version:\\s*(?<currentValue>\\S+)"
       ],
@@ -33,7 +33,7 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["/(^|/)requirements\\.yml$/"],
+      "fileMatch": ["(^|/)requirements\\.yml$"],
       "matchStrings": [
         "source:\\s*https://github\\.com/cozystack/ansible-cozystack\\.git\\s+type:\\s*git\\s+version:\\s*(?<currentValue>\\S+)"
       ],


### PR DESCRIPTION
PR #13 replaced `managerFilePatterns` with `fileMatch` but kept the `/…/` regex delimiters in the cozystack patterns. `fileMatch` expects plain regex strings, so patterns like `/roles/cozystack/defaults/main\.yml$/` never matched any files — the leading `/` and trailing `$/` made the regex unmatchable.

This broke automatic version bumping for cozystack releases since 2026-03-19. Four releases were missed: v1.1.4, v1.1.5, v1.2.0, v1.2.1.

The k3s manager was unaffected because its patterns were added directly without delimiters.

**Fix:** strip the `/` regex delimiters from all three cozystack `fileMatch` patterns, matching the style already used by the k3s manager.

**Verified locally** with `renovate --platform=local`: all 5 cozystack files and 4 k3s files are now detected correctly.

Assisted-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate dependency management configuration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->