### PR TITLE
feat(ubuntu): install drbd-dkms from LINBIT PPA for Secure Boot hosts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,73 @@ cozystack.installer Release Notes
 Unreleased
 ==========
 
+Ubuntu Secure Boot: pre-install drbd-dkms from LINBIT PPA.
+
+- ``examples/ubuntu/prepare-ubuntu.yml`` now installs ``drbd-dkms``
+  from the LINBIT PPA on Ubuntu hosts and configures
+  ``options drbd usermode_helper=disabled`` via
+  ``/etc/modprobe.d/cozystack-drbd.conf``. On hosts where UEFI
+  Secure Boot is enabled (most bare-metal installs and Secure-Boot
+  cloud SKUs), kernel lockdown rejects the unsigned modules built
+  by piraeus-operator's in-cluster compile path
+  (``Key was rejected by service``). With drbd-dkms installed,
+  dkms+shim signs the module against a per-host MOK key and
+  piraeus-operator's loader auto-detects host-loaded DRBD and
+  exits cleanly.
+- ``drbd-dkms`` Depends on ``drbd-utils (>= 9.28.0)``, so the userspace
+  is pulled onto the host as a transitive apt dependency. It is
+  unused at runtime — piraeus-operator's satellite container ships
+  its own copy and invokes that one. The playbook runs
+  ``systemctl mask drbd.service`` on the host so the userspace
+  cannot be enabled by accident and race the satellite.
+- The ``/etc/modprobe.d/`` drop-in is written BEFORE drbd-dkms is
+  installed so any auto-modprobe triggered by a future package
+  postinst loads the module with ``usermode_helper=disabled`` —
+  without that param, piraeus-operator's loader die()s on the
+  host-loaded module.
+- The initial ``modprobe drbd`` is tolerated (``ignore_errors: true``)
+  because the dkms-generated MOK key is not enrolled until the
+  operator confirms it via the shim console on the next reboot.
+  Persistence in ``/etc/modules-load.d/`` is gated on a successful
+  modprobe so ``systemd-modules-load.service`` does not fail every
+  boot before MOK enrollment. A reminder task fires when the modprobe
+  is deferred, pointing at the enrollment step.
+- New opt-out variable ``cozystack_enable_drbd_dkms`` (default
+  ``true``) for Talos hosts or operators who deliberately use the
+  in-cluster compile path. New variable ``cozystack_drbd_ppa``
+  (default ``ppa:linbit/linbit-drbd9-stack``) for sites that mirror
+  the LINBIT archive internally — overridable from inventory (the
+  default is in the task's ``| default(...)`` filter, not in
+  play-level ``vars:`` where it would outrank inventory).
+- Automated only on Ubuntu releases LINBIT keeps current — Jammy
+  (22.04) and Noble (24.04) as of 2026. Interim non-LTS releases
+  (Oracular 24.10, Plucky 25.04) and the next LTS before LINBIT
+  publishes for it are skipped with a notice. Gating is by release
+  name (``ansible_distribution_release``), not version number, because
+  LINBIT's PPA is keyed by release name and version-based gates
+  silently leak interim releases. The supported list is exposed as
+  ``cozystack_drbd_supported_releases`` (default ``[jammy, noble]``)
+  so operators can extend it from inventory once LINBIT publishes
+  for a new series. Debian, RHEL, and SUSE are not automated either —
+  LINBIT does not publish a Debian PPA, and the RHEL/SUSE flow needs
+  a different repo plus pre-signed kmods.
+
+Fix: tolerated-modprobe pattern previously silenced its own gates.
+
+- The pre-existing ``Load ZFS kernel module now`` and
+  ``Enable multipathd service`` tasks used ``failed_when: false`` to
+  tolerate failures. Ansible's ``failed_when`` is evaluated after the
+  module returns and rewrites the registered variable's ``failed``
+  attribute to match — so every downstream gate of the form
+  ``when: _cozystack_X.failed | default(false)`` was permanently
+  False. The persistence drop-in for ZFS was written even when
+  modprobe failed (which then crashed
+  ``systemd-modules-load.service`` every boot), and the multipathd
+  warn task never fired. Switched to ``ignore_errors: true``, which
+  lets the module's outcome through to the registered variable while
+  still tolerating the failure for play-execution purposes. Same fix
+  applied to the new DRBD modprobe task.
+
 Ubuntu 26.04 LTS support and namespace adoption.
 
 - ``examples/ubuntu/`` now boots end-to-end on Ubuntu 26.04 LTS. Two

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,9 +71,16 @@ Shallow "looks right" research will be rejected in plan review.
 - Kernel modules on nodes:
   - Drop a file in `/etc/modules-load.d/cozystack*.conf` for persistence.
   - `community.general.modprobe` for immediate load.
-  - Use `failed_when: false` only when the failure is benign (module
-    built into kernel, only one of two vendor-specific modules applies);
-    document the reason inline.
+  - **`failed_when: false` rewrites the registered variable's `failed`
+    field to `False`.** That breaks every downstream gate of the form
+    `when: _var.failed | default(false)`. Use `failed_when: false`
+    ONLY when nothing reads the registered variable (e.g., handler
+    tasks, or modprobe tasks gated by a follow-up `stat` on
+    `/sys/module/<name>` instead of by `.failed`). When the registered
+    variable IS consulted by a downstream `when:`, use
+    `ignore_errors: true` instead — it preserves the module's actual
+    `failed` flag while still tolerating the failure for play
+    execution.
 - Kernel headers: Piraeus builds DRBD against the running kernel, not
   the staged one, so pin to the running kernel when the distro allows.
   - Ubuntu/Debian: `linux-headers-{{ ansible_kernel }}` works.
@@ -97,8 +104,32 @@ their own pods. Do **not** install on the host:
 
 - `qemu-kvm`, `libvirt*` — KubeVirt bundles these.
 - `openvswitch-switch` / `openvswitch` userspace — Kube-OVN bundles OVS.
-- `drbd-utils`, `drbd-dkms`, `kmod-drbd*` — Piraeus init-container
-  compiles DRBD 9.x from source at runtime (kernel headers are enough).
+- `drbd-utils` userspace (`drbdadm`, `drbdmeta`, `drbdsetup`) — Piraeus
+  ships these in the satellite container.
+
+**Exception**: `drbd-dkms` IS installed on Ubuntu LTS hosts (22.04 /
+24.04) where the in-cluster Piraeus compile path is unavailable —
+UEFI Secure Boot enabled, kernel lockdown rejects the unsigned
+modules built by the in-cluster compiler with `Key was rejected by
+service`. See `cozystack_enable_drbd_dkms` in
+`examples/ubuntu/prepare-ubuntu.yml`. `drbd-dkms` Depends on
+`drbd-utils (>= 9.28.0)`, so `drbdadm`/`drbdmeta`/`drbdsetup`
+land on the host as a transitive apt dependency. They are
+unused — the satellite container ships its own copy. The
+playbook `systemctl mask`s `drbd.service` so the host-side
+userspace cannot be enabled accidentally and race the satellite.
+Talos ships pre-signed DRBD modules in extensions and does not
+need this.
+
+The collection does not automate the equivalent flow on RHEL/SUSE
+(LINBIT-managed RPM repo + pre-signed kmods). Operators on those
+distros either build and sign drbd-dkms manually or disable Secure
+Boot. LINBIT's PPA is keyed by Ubuntu release name and currently
+publishes for jammy + noble; interim releases (oracular, plucky)
+and the next LTS pre-publication fall back to the same manual
+path. The supported list is exposed as
+``cozystack_drbd_supported_releases`` so operators can extend it
+from inventory once LINBIT publishes for a new series.
 
 The host only needs the kernel modules and, for KVM, a working `/dev/kvm`.
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,30 @@ LINSTOR uses LVM thin pools by default for local block storage.
 
 #### Required: Kernel headers (Piraeus DRBD loader)
 
-LINSTOR uses DRBD 9.x for replication. The Piraeus operator's init container compiles the DRBD kernel module from source **against the running kernel** at runtime, so only kernel headers must be installed on the host — **no DRBD host packages are needed**. Pin the headers package to `ansible_kernel` so a staged-but-not-yet-booted kernel update doesn't install headers for the wrong kernel.
+LINSTOR uses DRBD 9.x for replication. The Piraeus operator's init container compiles the DRBD kernel module from source **against the running kernel** at runtime, so kernel headers must be installed on the host. Pin the headers package to `ansible_kernel` so a staged-but-not-yet-booted kernel update doesn't install headers for the wrong kernel.
 
 | Ubuntu/Debian | RHEL/CentOS | openSUSE/SLE |
 | --- | --- | --- |
 | `linux-headers-{{ ansible_kernel }}` | `kernel-devel-{{ ansible_kernel }}` plus `kernel-modules-extra-{{ ansible_kernel }}` | `kernel-default-devel` (zypper resolves to running kernel — SUSE's NVR format differs from `uname -r`) |
 
 On Oracle Linux the playbook auto-detects the UEK kernel (`uek` substring in `ansible_kernel`) and installs `kernel-uek-devel-{{ ansible_kernel }}` / `kernel-uek-modules-extra-{{ ansible_kernel }}` instead. Oracle Linux is not on the validated-end-to-end list; this code path is retained best-effort for users who still run the example playbook there. ZFS automation skips on UEK kernels because OpenZFS does not publish kmod builds for UEK.
+
+#### Required on Ubuntu Secure Boot hosts: drbd-dkms
+
+The in-cluster compile path above produces unsigned modules. UEFI Secure Boot's kernel lockdown rejects them at `insmod` time with `Key was rejected by service`, breaking the satellite Pod boot. Common on bare-metal Ubuntu installs (Secure Boot is the firmware default on most modern boards) and on Secure-Boot-enabled cloud SKUs; standard cloud-VM images on AWS/GCP/Azure typically ship without it and the in-cluster path works as-is.
+
+`examples/ubuntu/prepare-ubuntu.yml` installs `drbd-dkms` from the LINBIT PPA on Ubuntu LTS hosts (22.04 / 24.04) so dkms+shim signs the module against a per-host MOK key. The Piraeus loader detects the host-loaded module and exits cleanly without attempting its own compile + insmod.
+
+`drbd-dkms` has a hard apt dependency on `drbd-utils` (≥ 9.28.0), so `drbdadm`/`drbdmeta`/`drbdsetup` land on the host transitively. They are unused at runtime: piraeus-operator's satellite container ships its own copy of `drbd-utils` and invokes that one. The host's `drbd.service` ships disabled by maintainer; the playbook also `systemctl mask`s it so a future `systemctl enable drbd` cannot accidentally race the satellite container. Net result: the only DRBD state managed on the host is the kernel module.
+
+On hosts where Secure Boot is disabled the module loads on first run and no MOK enrollment is needed; the prepare playbook is still safe to run because the dkms build succeeds with an unsigned key the kernel happily accepts under unenforced lockdown. On Secure Boot hosts, the dkms-generated MOK key must be enrolled at the shim console on the next reboot (Enroll MOK → View key → Continue → dkms password). The playbook tolerates the initial modprobe failure pending enrollment and emits a reminder; idempotent re-run after enrollment converges.
+
+Variables (define in inventory to override):
+
+- `cozystack_enable_drbd_dkms` (bool, default `true`): set `false` on Talos hosts (Talos ships signed DRBD modules in extensions) or where Secure Boot is disabled and you prefer the in-cluster compile path.
+- `cozystack_drbd_ppa` (string, default `ppa:linbit/linbit-drbd9-stack`): point at a local mirror of the LINBIT archive.
+
+The PPA-based path is automated only on Ubuntu releases LINBIT keeps current — Jammy (22.04 LTS) and Noble (24.04 LTS) as of 2026. Interim non-LTS releases (Oracular 24.10, Plucky 25.04, etc.) and the next LTS (Resolute 26.04) before LINBIT publishes for them are not in the LINBIT PPA, so the playbook skips the install and emits a notice on those hosts. The supported list is exposed as `cozystack_drbd_supported_releases` (default `[jammy, noble]`); operators can extend it from inventory once LINBIT publishes for a new series, without waiting for a collection release. Operators on unsupported releases must build and sign `drbd-dkms` manually, downgrade to a supported LTS, or disable Secure Boot. Debian is not automated either (no LINBIT Debian PPA). RHEL/SUSE need a separate flow (LINBIT-managed RPM repo + pre-signed kmods) and are out of scope for this collection.
 
 #### Required: Multipath DRBD blacklist
 
@@ -167,9 +184,10 @@ informational notice:
 
 Other subsystem notes:
 
-- **Ubuntu 26.04 LTS:** two changes to be aware of.
+- **Ubuntu 26.04 LTS:** three changes to be aware of.
   1. *Auto-applied by `examples/ubuntu/site.yml`*: `sudo-rs` ships as the default `/usr/bin/sudo` alternative and does not honour ansible's `become_method: sudo` privilege-escalation pseudo-tty — every `become: true` task hangs with `Timeout (12s) waiting for privilege escalation prompt`. The classical sudo binary is co-installed at `/usr/bin/sudo.ws`. `site.yml` imports `prepare-sudo.yml` first, which switches the `sudo` alternative back via `update-alternatives` using a `raw` command (so it works even when become is broken). The play is a no-op on releases without sudo-rs. If you bypass `site.yml` and call the prepare playbooks directly, run `prepare-sudo.yml` before any task with `become: true` on 26.04 hosts.
   2. *Manual inventory setting on 26.04 hosts*: the playbook auto-skips `linux-modules-extra-*` on Ubuntu 26.04+ because the package no longer exists for kernel 7.x — `openvswitch` and `vport-geneve` are bundled into `linux-image-generic`. The auto-skip relies on `ansible_distribution_version`; on hosts where that fact is unreliable, set `cozystack_ubuntu_extra_packages: []` in inventory to skip the apt install explicitly.
+  3. *DRBD via `drbd-dkms` is not automated on releases LINBIT does not publish for*: LINBIT's PPA only ships drbd-dkms for the LTS series they keep current (Jammy 22.04 + Noble 24.04 as of 2026). Interim releases (Oracular 24.10, Plucky 25.04) and the next LTS (Resolute 26.04) before LINBIT publishes are skipped with a notice; on Secure Boot hosts the in-cluster compile path will fail with `Key was rejected by service`. Build and sign `drbd-dkms` manually, downgrade to a supported LTS, extend `cozystack_drbd_supported_releases` from inventory once LINBIT publishes for your release, or disable Secure Boot.
 - **Cloud providers (Ubuntu on OCI, AWS, GCP):** stock Ubuntu cloud images ship an iptables INPUT chain that ends with `REJECT icmp-host-prohibited`, which blocks k3s ports 2380/6443 between nodes. Set `cozystack_flush_iptables: true` in your inventory so the prepare playbook flushes the INPUT chain before k3s installs. Oracle Linux images on OCI do not have this restriction out of the box.
 - **Rocky 10 / Alma 10 (and other RHEL 10 rebuilds):** the `iptables` userspace binary is not installed by default. `examples/rhel/prepare-rhel.yml` installs `iptables-nft` so the `cozystack_flush_iptables` task and k3s kube-proxy replacement have a working `iptables` wrapper over nftables.
 - **ARM64 (aarch64):** OpenZFS does not publish aarch64 RPMs for RHEL-family distributions via `zfsonlinux.org/epel`. Cozystack itself targets x86_64.
@@ -345,6 +363,9 @@ vars to opt out of the corresponding prepare step:
 | `cozystack_enable_kubevirt` | `true` | Example playbooks: load KubeVirt kernel modules. Set `false` to skip. |
 | `cozystack_flush_iptables` | `false` | Example playbooks: flush the iptables INPUT chain before k3s installs. Set `true` on Ubuntu/Debian cloud images (OCI/AWS/GCP) where the default INPUT chain ends with `REJECT icmp-host-prohibited` and blocks k3s inter-node ports 2380/6443. |
 | `cozystack_zfs_release_rpm_extra` | `{}` | `examples/rhel/` only: merged on top of the built-in `cozystack_zfs_release_rpm_by_major` dict, so you can add (or override) a single EL-major → OpenZFS release RPM entry from inventory without wiping the base dict. Example: `{"10": "https://zfsonlinux.org/epel/zfs-release-X-Y.el10.noarch.rpm"}` once upstream ships one. |
+| `cozystack_enable_drbd_dkms` | `true` | `examples/ubuntu/` only: install `drbd-dkms` from the LINBIT PPA on Ubuntu LTS 22.04 / 24.04 hosts so DRBD's kernel module is signed via dkms+shim under Secure Boot. Set `false` on Talos hosts (Talos ships pre-signed DRBD modules in extensions) or where Secure Boot is disabled and the in-cluster compile path is preferred. The toggle stops *future* installs but does NOT undo a prior install — manually `apt purge drbd-dkms` and remove the LINBIT entry from `/etc/apt/sources.list.d/` if you flipped to `false` after a successful run. |
+| `cozystack_drbd_ppa` | `ppa:linbit/linbit-drbd9-stack` | `examples/ubuntu/` only: override to point at a Launchpad PPA mirror of the LINBIT archive. `ansible.builtin.apt_repository` resolves the signing key for `ppa:` URIs by querying Launchpad's REST API directly (no extra packages required). Non-Launchpad URIs (`deb http://internal-mirror/...`) work but you must manage the apt signing key separately — drop a keyring under `/etc/apt/keyrings/` and add `signed-by=` to the repo line. |
+| `cozystack_drbd_supported_releases` | `[jammy, noble]` | `examples/ubuntu/` only: list of Ubuntu release codenames LINBIT's PPA publishes drbd-dkms for. Extend from inventory when LINBIT adds a new series (e.g. `[jammy, noble, resolute]`) without waiting for a collection release. The playbook skips the install and emits a notice on Ubuntu hosts whose `ansible_distribution_release` is not in this list. |
 
 ## Using with k3s
 

--- a/examples/ubuntu/prepare-ubuntu.yml
+++ b/examples/ubuntu/prepare-ubuntu.yml
@@ -477,6 +477,8 @@
     - name: Mask host drbd.service
       ansible.builtin.systemd:
         name: drbd.service
+        enabled: false
+        state: stopped
         masked: true
       when:
         - cozystack_enable_drbd_dkms | default(true) | bool

--- a/examples/ubuntu/prepare-ubuntu.yml
+++ b/examples/ubuntu/prepare-ubuntu.yml
@@ -29,6 +29,11 @@
       # Kernel headers — Piraeus operator compiles DRBD 9.x at runtime.
       # Pin to ansible_kernel so headers match the running kernel.
       - "linux-headers-{{ ansible_kernel }}"
+      # gnupg is required by ansible.builtin.apt_repository for PPA
+      # signing-key fingerprint handling. Ubuntu 24.04+ removed
+      # apt-key, so gpg is the only path; stock cloud images already
+      # ship it but minimal/container images may not.
+      - gnupg
 
     # Ubuntu-only: linux-modules-extra-* ships openvswitch and geneve
     # on cloud/minimal kernels. Debian includes these in its base
@@ -86,6 +91,23 @@
       - { name: net.bridge.bridge-nf-call-ip6tables, value: "1" }
       - { name: vm.swappiness, value: "1" }
 
+    # DRBD via dkms on Ubuntu hosts where the in-cluster compile path is
+    # unavailable (UEFI Secure Boot + kernel lockdown rejects the
+    # unsigned modules piraeus-operator builds in-cluster — "Key was
+    # rejected by service"). Pre-installing drbd-dkms lets dkms+shim
+    # sign the module with a per-host MOK key, and piraeus-operator's
+    # loader auto-detects host-loaded DRBD and exits cleanly. Secure
+    # Boot is the common case on bare-metal installs and some bare-metal
+    # cloud SKUs; standard cloud-VM images on AWS/GCP/Azure usually ship
+    # without Secure Boot enforcement and the in-cluster compile path
+    # works as before.
+    #
+    # Set cozystack_enable_drbd_dkms: false on Talos hosts (Talos ships
+    # signed DRBD modules in extensions) or where Secure Boot is
+    # disabled and you prefer the in-cluster compile path.
+    # Override cozystack_drbd_ppa from inventory to point at a local
+    # mirror of the LINBIT archive.
+
     # k3s server arguments required by Cozystack.
     # These disable built-in components that Cozystack replaces.
     cozystack_k3s_server_args: >-
@@ -109,7 +131,12 @@
       ansible.builtin.systemd:
         name: multipathd
         state: restarted
-      failed_when: false  # tolerated: same reason as the enable task below
+      # Handler — no register, no downstream gate consults the result,
+      # so failed_when: false is safe here. Tolerated reason: VMs /
+      # kernels without dm_multipath. (See CLAUDE.md for why
+      # ignore_errors is required for tasks WHOSE registered variable
+      # IS consulted downstream.)
+      failed_when: false
 
   tasks:
     - name: Create k3s_cluster group for k3s.orchestration
@@ -127,6 +154,19 @@
       ansible.builtin.set_fact:
         server_config_yaml: "{{ cozystack_k3s_server_config_yaml }}"
       when: server_config_yaml is not defined
+
+    # Single source of truth for the LINBIT-PPA-supported release
+    # codename list. Inventory may extend the list (e.g.
+    # `cozystack_drbd_supported_releases: [jammy, noble, resolute]`)
+    # once LINBIT publishes for a new series; the set_fact only fires
+    # when the inventory does not already define the variable, so
+    # inventory wins.
+    - name: Default cozystack_drbd_supported_releases when unset
+      ansible.builtin.set_fact:
+        cozystack_drbd_supported_releases:
+          - jammy
+          - noble
+      when: cozystack_drbd_supported_releases is not defined
 
     - name: Install required packages
       ansible.builtin.apt:
@@ -242,13 +282,16 @@
         enabled: true
         state: started
 
+    # ignore_errors (not failed_when: false) so the registered var
+    # keeps `failed` for the warn task below — failed_when: false
+    # would rewrite it to False and silence the warning.
     - name: Enable multipathd service
       ansible.builtin.systemd:
         name: multipathd
         enabled: true
         state: started
       register: _cozystack_multipathd
-      failed_when: false  # tolerated: VMs / kernels without dm_multipath
+      ignore_errors: true  # tolerated: VMs / kernels without dm_multipath
 
     - name: Warn if multipathd failed to start
       ansible.builtin.debug:
@@ -281,6 +324,10 @@
         - cozystack_enable_zfs | default(true) | bool
         - ansible_distribution == 'Ubuntu'
 
+    # ignore_errors (not failed_when: false) so the registered var
+    # keeps `failed` truthful for downstream gates — failed_when: false
+    # would rewrite it to False and break the persistence + warn tasks
+    # below.
     - name: Load ZFS kernel module now
       community.general.modprobe:
         name: zfs
@@ -288,7 +335,7 @@
       when:
         - cozystack_enable_zfs | default(true) | bool
         - ansible_distribution == 'Ubuntu'
-      failed_when: false  # tolerated: Secure Boot / unsigned-module hosts
+      ignore_errors: true  # tolerated: Secure Boot / unsigned-module hosts
 
     # Only persist zfs in modules-load.d if the module actually loaded —
     # otherwise systemd-modules-load.service will fail on every boot.
@@ -327,6 +374,191 @@
         ansible_distribution != 'Ubuntu' or
         (_cozystack_zfs_modprobe is defined and
          _cozystack_zfs_modprobe.failed | default(false))
+
+    # DRBD on Debian: not automated. LINBIT does not publish a Debian
+    # PPA, and the in-cluster compile path that piraeus-operator falls
+    # back to fails on Debian 12 hosts with Secure Boot enabled (same
+    # 'Key was rejected by service' as the Ubuntu case). Operators must
+    # build and sign drbd-dkms manually or disable Secure Boot.
+    - name: Warn that DRBD on Debian needs manual setup
+      ansible.builtin.debug:
+        msg: >-
+          NOTE: DRBD via dkms is not automated on Debian. piraeus-operator's
+          in-cluster compile path will fail on Secure Boot hosts. Either
+          disable Secure Boot, or build and sign drbd-dkms manually.
+          Set cozystack_enable_drbd_dkms: false to silence this notice.
+      when:
+        - cozystack_enable_drbd_dkms | default(true) | bool
+        - ansible_distribution == 'Debian'
+
+    # DRBD on Ubuntu releases LINBIT does not publish for: not
+    # automated. LINBIT's PPA only ships drbd-dkms for the LTS series
+    # they keep current (Jammy 22.04 + Noble 24.04 as of 2026);
+    # interim releases (Oracular 24.10, Plucky 25.04, …) and the
+    # next LTS (Resolute 26.04) before LINBIT publishes for them will
+    # see apt update fail on the PPA's missing Release file, then
+    # 'Unable to locate package drbd-dkms'. Gating is by release name
+    # because LINBIT's PPA is keyed by release name, not version
+    # number. Operators can extend cozystack_drbd_supported_releases
+    # from inventory once LINBIT publishes for a new series, without
+    # waiting for a collection release.
+    - name: Warn that DRBD via LINBIT PPA is unavailable on this Ubuntu release
+      ansible.builtin.debug:
+        msg: >-
+          NOTE: LINBIT's PPA does not publish drbd-dkms for Ubuntu
+          {{ ansible_distribution_release }} ({{ ansible_distribution_version }});
+          only the LTS series LINBIT keeps current are supported
+          (jammy / noble as of 2026; extend
+          cozystack_drbd_supported_releases from inventory once they
+          publish a new one). On Secure Boot hosts the in-cluster
+          compile path will fail with 'Key was rejected by service'.
+          Build and sign drbd-dkms manually, downgrade to a supported
+          LTS, or disable Secure Boot. Set
+          cozystack_enable_drbd_dkms: false to silence this notice.
+      when:
+        - cozystack_enable_drbd_dkms | default(true) | bool
+        - ansible_distribution == 'Ubuntu'
+        - ansible_distribution_release not in cozystack_drbd_supported_releases
+
+    # DRBD via dkms from LINBIT PPA (Ubuntu releases listed in
+    # cozystack_drbd_supported_releases — jammy/noble by default;
+    # Debian + unsupported Ubuntu releases get the warn tasks above).
+    # Required for non-Talos installs on Secure Boot hosts;
+    # piraeus-operator's loader auto-detects the host-loaded module
+    # and skips compilation.
+    #
+    # Order matters: the modprobe.d drop-in is written BEFORE
+    # drbd-dkms is installed so any auto-modprobe triggered by the
+    # package's postinst (or future dkms hook changes) loads the
+    # module with usermode_helper=disabled. Without that param,
+    # piraeus-operator's loader die()s on the host-loaded module
+    # (see LINBIT/drbd docker/entry.sh).
+    - name: Configure DRBD module parameters
+      ansible.builtin.copy:
+        dest: /etc/modprobe.d/cozystack-drbd.conf
+        mode: "0644"
+        content: |
+          options drbd usermode_helper=disabled
+      when:
+        - cozystack_enable_drbd_dkms | default(true) | bool
+        - ansible_distribution == 'Ubuntu'
+        - ansible_distribution_release in cozystack_drbd_supported_releases
+
+    - name: Add LINBIT PPA for drbd-dkms
+      ansible.builtin.apt_repository:
+        repo: "{{ cozystack_drbd_ppa | default('ppa:linbit/linbit-drbd9-stack') }}"
+        state: present
+        update_cache: true
+      when:
+        - cozystack_enable_drbd_dkms | default(true) | bool
+        - ansible_distribution == 'Ubuntu'
+        - ansible_distribution_release in cozystack_drbd_supported_releases
+
+    # drbd-dkms has a hard apt dependency on drbd-utils (>= 9.28.0)
+    # and pulls it onto the host transitively. The host copy of
+    # drbdadm/drbdmeta/drbdsetup is never invoked at runtime —
+    # piraeus-operator's satellite container ships its own
+    # drbd-utils and uses that one. The host's drbd.service ships
+    # disabled by maintainer; we mask it below to prevent accidental
+    # `systemctl enable drbd` from conflicting with the satellite.
+    - name: Install drbd-dkms
+      ansible.builtin.apt:
+        name: drbd-dkms
+        state: present
+      when:
+        - cozystack_enable_drbd_dkms | default(true) | bool
+        - ansible_distribution == 'Ubuntu'
+        - ansible_distribution_release in cozystack_drbd_supported_releases
+
+    # Mask drbd.service so the host-side userspace cannot be enabled
+    # by accident. piraeus-operator manages all DRBD resources via its
+    # own satellite container; host-side drbd.service would race with
+    # it.
+    - name: Mask host drbd.service
+      ansible.builtin.systemd:
+        name: drbd.service
+        masked: true
+      when:
+        - cozystack_enable_drbd_dkms | default(true) | bool
+        - ansible_distribution == 'Ubuntu'
+        - ansible_distribution_release in cozystack_drbd_supported_releases
+
+    # ignore_errors (not failed_when: false) so the registered var
+    # preserves the module's `failed` flag — `failed_when: false`
+    # rewrites it to False and silently breaks every downstream gate
+    # in this play. Tolerated outcome is the same; introspectable
+    # state is not.
+    - name: Load DRBD kernel module now
+      community.general.modprobe:
+        name: drbd
+        params: usermode_helper=disabled
+      register: _cozystack_drbd_modprobe
+      when:
+        - cozystack_enable_drbd_dkms | default(true) | bool
+        - ansible_distribution == 'Ubuntu'
+        - ansible_distribution_release in cozystack_drbd_supported_releases
+      ignore_errors: true  # tolerated: Secure Boot before MOK enrollment
+
+    # Only persist drbd in modules-load.d if the module actually loaded —
+    # otherwise systemd-modules-load.service will fail on every boot.
+    - name: Load DRBD kernel module at boot
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/cozystack-drbd.conf
+        mode: "0644"
+        content: "drbd\n"
+      when:
+        - cozystack_enable_drbd_dkms | default(true) | bool
+        - ansible_distribution == 'Ubuntu'
+        - ansible_distribution_release in cozystack_drbd_supported_releases
+        - _cozystack_drbd_modprobe is defined
+        - not (_cozystack_drbd_modprobe.failed | default(false))
+
+    - name: Warn if DRBD module failed to load
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: modprobe drbd failed ({{ _cozystack_drbd_modprobe.msg | default('unknown') }}).
+          On Secure Boot hosts the dkms-generated MOK key must be enrolled
+          via the shim console on first reboot (Enroll MOK -> View key ->
+          Continue -> dkms password). Re-run this playbook after enrollment;
+          piraeus-operator will not start until DRBD is loaded with
+          usermode_helper=disabled. Set cozystack_enable_drbd_dkms: false to silence.
+      when:
+        - cozystack_enable_drbd_dkms | default(true) | bool
+        - ansible_distribution == 'Ubuntu'
+        - ansible_distribution_release in cozystack_drbd_supported_releases
+        - _cozystack_drbd_modprobe is defined
+        - _cozystack_drbd_modprobe.failed | default(false)
+
+    # Remove the drop-in in any case where DRBD should not auto-load:
+    # opt-out, non-Ubuntu, Ubuntu release not in
+    # cozystack_drbd_supported_releases (LINBIT PPA does not ship for
+    # those), or modprobe failed pending MOK enrollment.
+    - name: Remove DRBD modules-load drop-in when not active
+      ansible.builtin.file:
+        path: /etc/modules-load.d/cozystack-drbd.conf
+        state: absent
+      when: >-
+        not (cozystack_enable_drbd_dkms | default(true) | bool) or
+        ansible_distribution != 'Ubuntu' or
+        ansible_distribution_release not in cozystack_drbd_supported_releases or
+        (_cozystack_drbd_modprobe is defined and
+         _cozystack_drbd_modprobe.failed | default(false))
+
+    # When the operator opts out (cozystack_enable_drbd_dkms: false),
+    # runs on a non-Ubuntu host, or runs on an Ubuntu release LINBIT's
+    # PPA does not publish for, the modprobe.d drop-in serves no
+    # purpose — remove it for symmetry with the modules-load.d
+    # cleanup. The modprobe-failure case is intentionally NOT in this
+    # `when:` — the param is still needed once the module loads at
+    # the next reboot after MOK enrollment.
+    - name: Remove DRBD modprobe.d drop-in when not active
+      ansible.builtin.file:
+        path: /etc/modprobe.d/cozystack-drbd.conf
+        state: absent
+      when: >-
+        not (cozystack_enable_drbd_dkms | default(true) | bool) or
+        ansible_distribution != 'Ubuntu' or
+        ansible_distribution_release not in cozystack_drbd_supported_releases
 
     # KubeVirt kernel modules (opt-out via cozystack_enable_kubevirt=false).
     # QEMU and libvirt run inside KubeVirt pods; no host packages needed.

--- a/tests/unit/playbooks/test_ubuntu_examples.py
+++ b/tests/unit/playbooks/test_ubuntu_examples.py
@@ -228,3 +228,568 @@ def test_linux_modules_extra_auto_skips_on_26_04():
         "linux-modules-extra-* does not exist for kernel 7.x. "
         "Got: %r" % when
     )
+
+
+# prepare-ubuntu.yml — DRBD/Secure Boot invariants
+
+
+def test_drbd_modprobe_is_tolerated_via_ignore_errors():
+    # piraeus-operator's loader needs DRBD host-loaded with
+    # usermode_helper=disabled; on Secure Boot hosts the dkms key is not
+    # enrolled until the operator confirms MOK at the next reboot, so the
+    # initial modprobe must be tolerated. The tolerance MUST be expressed
+    # as `ignore_errors: true`, not `failed_when: false`. The latter
+    # rewrites the registered variable's `failed` field to False, which
+    # silently breaks the persistence and warn tasks that gate on
+    # `_cozystack_drbd_modprobe.failed`. ignore_errors preserves the
+    # module's actual outcome.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(plays, "Load DRBD kernel module now")
+    assert task.get("ignore_errors") is True, (
+        "modprobe drbd must use `ignore_errors: true` so the registered "
+        "var preserves .failed for downstream gates; got ignore_errors=%r"
+        % task.get("ignore_errors")
+    )
+    assert "failed_when" not in task, (
+        "modprobe drbd must NOT use failed_when — it rewrites .failed "
+        "and breaks every downstream gate that consults the registered "
+        "variable. Use ignore_errors instead. Got task keys: %r"
+        % list(task.keys())
+    )
+    params = task.get("community.general.modprobe", {}).get("params", "")
+    assert "usermode_helper=disabled" in params, (
+        "modprobe must pass usermode_helper=disabled — without it "
+        "piraeus-operator's loader die()s on the host-loaded module. "
+        "Got params=%r" % params
+    )
+
+
+def test_zfs_modprobe_uses_ignore_errors_not_failed_when():
+    # Same bug fix applied to the pre-existing ZFS pattern: this PR
+    # copied the broken shape from there, so per the project rule it
+    # owns fixing both. Without this, the ZFS persistence gate at
+    # `Load ZFS kernel module at boot` writes /etc/modules-load.d/
+    # even when modprobe failed, which then crashes
+    # systemd-modules-load.service on every boot.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(plays, "Load ZFS kernel module now")
+    assert task.get("ignore_errors") is True, (
+        "modprobe zfs must use `ignore_errors: true`; got %r"
+        % task.get("ignore_errors")
+    )
+    assert "failed_when" not in task, (
+        "modprobe zfs must NOT use failed_when (rewrites .failed). "
+        "Got task keys: %r" % list(task.keys())
+    )
+
+
+def test_multipathd_enable_uses_ignore_errors_not_failed_when():
+    # `Enable multipathd service` registers _cozystack_multipathd and
+    # the warn task downstream gates on `.failed`. failed_when: false
+    # would silently always-pass that gate. Same fix as DRBD/ZFS.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(plays, "Enable multipathd service")
+    assert task.get("ignore_errors") is True, (
+        "Enable multipathd must use ignore_errors so the warn task "
+        "fires on real failure; got %r" % task.get("ignore_errors")
+    )
+    assert "failed_when" not in task, (
+        "Enable multipathd must NOT use failed_when. Got: %r"
+        % list(task.keys())
+    )
+
+
+def test_drbd_modules_load_drop_in_gated_on_modprobe_success():
+    # Persisting drbd in /etc/modules-load.d/ when modprobe failed (no
+    # MOK yet) makes systemd-modules-load.service fail every boot. The
+    # write task must be gated on `_cozystack_drbd_modprobe.failed` being
+    # false, mirroring the ZFS pattern.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(plays, "Load DRBD kernel module at boot")
+    when = task.get("when") or []
+    when_blob = " ".join(when) if isinstance(when, list) else str(when)
+    assert "_cozystack_drbd_modprobe" in when_blob, (
+        "persistence gate must reference _cozystack_drbd_modprobe so "
+        "drbd is not written to modules-load.d when modprobe failed. "
+        "Got: %r" % when
+    )
+    assert "not (_cozystack_drbd_modprobe.failed" in when_blob, (
+        "persistence gate must require modprobe success: "
+        "`not (_cozystack_drbd_modprobe.failed | default(false))`. "
+        "Got: %r" % when
+    )
+
+
+def test_drbd_modprobe_d_writes_usermode_helper_disabled():
+    # piraeus-operator's loader (LINBIT/drbd docker/entry.sh) explicitly
+    # die()s on a host-loaded drbd module that does not have
+    # usermode_helper=disabled. Document the contract structurally so
+    # future edits don't drop the param.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(plays, "Configure DRBD module parameters")
+    content = task.get("ansible.builtin.copy", {}).get("content", "")
+    assert "usermode_helper=disabled" in content, (
+        "/etc/modprobe.d/cozystack-drbd.conf must set "
+        "usermode_helper=disabled; got %r" % content
+    )
+
+
+def test_drbd_tasks_are_ubuntu_only_and_opt_outable():
+    # All DRBD install tasks must gate on Ubuntu, on the supported
+    # release list (LINBIT PPA is keyed by release name — version
+    # gating would let interim releases like Oracular 24.10 / Plucky
+    # 25.04 reach the PPA add task and fail mid-playbook on a 404
+    # Release file), and on cozystack_enable_drbd_dkms. Talos hosts
+    # and any operator who deliberately runs the in-cluster compile
+    # path must be able to skip the entire block from inventory.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    drbd_task_names = [
+        "Add LINBIT PPA for drbd-dkms",
+        "Install drbd-dkms",
+        "Configure DRBD module parameters",
+        "Load DRBD kernel module now",
+        "Load DRBD kernel module at boot",
+        "Mask host drbd.service",
+    ]
+    for name in drbd_task_names:
+        task = _find_task(plays, name)
+        when = task.get("when") or []
+        when_blob = " ".join(when) if isinstance(when, list) else str(when)
+        assert "cozystack_enable_drbd_dkms" in when_blob, (
+            "%r must gate on cozystack_enable_drbd_dkms for opt-out; "
+            "got when=%r" % (name, when)
+        )
+        assert "ansible_distribution == 'Ubuntu'" in when_blob, (
+            "%r must gate on Ubuntu — Debian/RHEL/SUSE need different "
+            "DRBD install paths; got when=%r" % (name, when)
+        )
+        # Gate by release name, not version number — LINBIT's PPA is
+        # keyed by release name, and version-based gates miss interim
+        # releases between current LTS and the next LTS (24.10 / 25.04
+        # would slip through `< 26.04`).
+        assert (
+            "ansible_distribution_release in cozystack_drbd_supported_releases"
+            in when_blob
+        ), (
+            "%r must gate on the bare "
+            "`ansible_distribution_release in cozystack_drbd_supported_releases` "
+            "(default is materialized once via set_fact at the top of "
+            "the play; per-task `default()` would let drift between "
+            "sites slip through). Got when=%r" % (name, when)
+        )
+
+
+def test_drbd_default_release_list_set_via_set_fact():
+    # Single source of truth. The default release list is materialized
+    # once via set_fact `Default cozystack_drbd_supported_releases when
+    # unset` at the top of tasks; every gate downstream reads the bare
+    # variable. Spreading `default([...])` across 11 task `when:`
+    # clauses risks drift (install vs cleanup vs warn site disagreeing
+    # on what the default is). This test pins the single source.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(
+        plays,
+        "Default cozystack_drbd_supported_releases when unset",
+    )
+    f = task.get("ansible.builtin.set_fact", {})
+    items = f.get("cozystack_drbd_supported_releases")
+    assert items == ["jammy", "noble"], (
+        "Default release list must be exactly ['jammy', 'noble'] — "
+        "those are the only series LINBIT's PPA currently publishes "
+        "drbd-dkms for. Adding a release that is not yet in the PPA "
+        "would cause apt update to fail on a 404 Release file. "
+        "Got: %r" % items
+    )
+    when = task.get("when")
+    assert when == "cozystack_drbd_supported_releases is not defined", (
+        "set_fact must only fire when the variable is not already "
+        "defined, so inventory overrides win. Got when=%r" % when
+    )
+
+
+def test_drbd_warn_on_unsupported_ubuntu_release():
+    # The warn task must fire on every Ubuntu release LINBIT does
+    # NOT publish for — that includes 24.10 (Oracular), 25.04
+    # (Plucky), 26.04 (Resolute), and any future series until the
+    # operator extends cozystack_drbd_supported_releases. Mirrors
+    # the Debian warn-task pattern.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(
+        plays,
+        "Warn that DRBD via LINBIT PPA is unavailable on this Ubuntu release",
+    )
+    when = task.get("when") or []
+    when_blob = " ".join(when) if isinstance(when, list) else str(when)
+    assert "ansible_distribution == 'Ubuntu'" in when_blob, (
+        "Ubuntu-release warn task must gate on Ubuntu; got %r" % when
+    )
+    assert (
+        "ansible_distribution_release not in" in when_blob
+        and "cozystack_drbd_supported_releases" in when_blob
+    ), (
+        "Ubuntu-release warn task must fire when the host's release "
+        "is NOT in cozystack_drbd_supported_releases (interim + new "
+        "LTS pre-publication). Got: %r" % when
+    )
+    assert "cozystack_enable_drbd_dkms" in when_blob, (
+        "Ubuntu-release warn task must respect the opt-out toggle; "
+        "got %r" % when
+    )
+
+
+def _task_index(plays, task_name):
+    # Find the index of a task within its play.tasks list.
+    for play in plays:
+        tasks = play.get("tasks", []) or []
+        for i, task in enumerate(tasks):
+            if task.get("name") == task_name:
+                return i
+    raise AssertionError("task %r not found" % task_name)
+
+
+def test_gnupg_is_in_required_packages():
+    # ansible.builtin.apt_repository with a `ppa:` URI needs `gpg` to
+    # process Launchpad's signing-key fingerprint. Ubuntu 24.04+
+    # removed apt-key, so gpg (from gnupg) is the only available
+    # path. Stock cloud images ship it but minimal/container images
+    # may not — add it explicitly to cozystack_packages so the
+    # PPA add task does not blow up with "Either apt-key or gpg
+    # binary is required, but neither could be found." in the wild.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    play = plays[0]
+    pkgs = play.get("vars", {}).get("cozystack_packages") or []
+    assert "gnupg" in pkgs, (
+        "cozystack_packages must include 'gnupg' so apt_repository's "
+        "PPA flow has gpg available on minimal Ubuntu images. "
+        "Got: %r" % pkgs
+    )
+
+
+def test_drbd_modprobe_d_written_before_apt_install():
+    # The /etc/modprobe.d/cozystack-drbd.conf drop-in must exist BEFORE
+    # drbd-dkms is installed. dkms postinst hooks have historically
+    # changed across distro versions; if a future drbd-dkms postinst
+    # auto-modprobes drbd, the module must already be configured with
+    # usermode_helper=disabled or piraeus-operator's loader die()s on
+    # the host-loaded module.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    modprobe_d_idx = _task_index(plays, "Configure DRBD module parameters")
+    install_idx = _task_index(plays, "Install drbd-dkms")
+    assert modprobe_d_idx < install_idx, (
+        "Configure DRBD module parameters (idx %d) must run BEFORE "
+        "Install drbd-dkms (idx %d) so any package-side modprobe "
+        "respects usermode_helper=disabled"
+        % (modprobe_d_idx, install_idx)
+    )
+
+
+def test_readme_does_not_cite_launchpadlib():
+    # ansible.builtin.apt_repository does NOT use python3-launchpadlib
+    # for PPA key resolution — it hits Launchpad's REST API directly
+    # via fetch_url. README must not cite launchpadlib as the
+    # mechanism, otherwise readers facing a non-PPA mirror will
+    # install an unused dependency or chase a phantom break.
+    readme_path = os.path.join(REPO_ROOT, "README.md")
+    with open(readme_path, "r", encoding="utf-8") as fh:
+        readme = fh.read()
+    assert "python3-launchpadlib" not in readme, (
+        "README must not mention python3-launchpadlib as a PPA "
+        "key-resolution mechanism — apt_repository uses Launchpad's "
+        "REST API directly via fetch_url. Naming launchpadlib will "
+        "send readers down a dead-end install path."
+    )
+    assert "launchpadlib" not in readme, (
+        "Same as above: 'launchpadlib' is not part of the PPA flow "
+        "this collection uses."
+    )
+
+
+def test_no_launchpadlib_install_task():
+    # ansible.builtin.apt_repository with a `ppa:` URI does NOT need
+    # python3-launchpadlib — the module hits Launchpad's REST API
+    # directly via fetch_url (urllib-based) since at least
+    # ansible-core 2.10. Installing launchpadlib pulls a 6MB+
+    # transitive dependency chain (lazr.restfulclient, oauth,
+    # httplib2, keyring, ...) for no functional gain. Lock the
+    # absence in so the task does not creep back in.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    for play in plays:
+        for task in play.get("tasks", []) or []:
+            apt = task.get("ansible.builtin.apt", {}) or {}
+            name = apt.get("name")
+            names = name if isinstance(name, list) else [name]
+            for n in names:
+                assert n != "python3-launchpadlib", (
+                    "Do not install python3-launchpadlib — "
+                    "ansible.builtin.apt_repository with a ppa: URI "
+                    "uses Launchpad's REST API directly via fetch_url, "
+                    "no launchpadlib import. The package adds a 6MB+ "
+                    "transitive dependency chain for no functional "
+                    "gain. Found in task %r." % task.get("name")
+                )
+
+
+def test_drbd_ppa_var_overridable_from_inventory():
+    # cozystack_drbd_ppa must NOT be defined in play-level vars: —
+    # play-level vars outrank inventory, which would silently break
+    # the documented "override to point at a local mirror" use case.
+    # The default belongs in the task's `| default(...)` filter so
+    # inventory wins.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    for play in plays:
+        play_vars = play.get("vars", {}) or {}
+        assert "cozystack_drbd_ppa" not in play_vars, (
+            "cozystack_drbd_ppa must not be set in play-level `vars:` — "
+            "play vars outrank inventory and break the override path. "
+            "Move the default to `| default(...)` in the task using it."
+        )
+
+    task = _find_task(plays, "Add LINBIT PPA for drbd-dkms")
+    repo = task.get("ansible.builtin.apt_repository", {}).get("repo", "")
+    assert "default(" in repo and "linbit-drbd9-stack" in repo, (
+        "Add LINBIT PPA repo expression must use `| default('ppa:...')` "
+        "so the value comes from inventory if set; got %r" % repo
+    )
+
+
+def test_drbd_warn_task_fires_only_on_modprobe_failure():
+    # The warn-on-failure debug task must gate on the modprobe failure
+    # so it is silent on hosts where DRBD loaded fine. Without that
+    # gate, the reminder fires every run on every host and trains
+    # operators to ignore it.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(plays, "Warn if DRBD module failed to load")
+    when = task.get("when") or []
+    when_blob = " ".join(when) if isinstance(when, list) else str(when)
+    assert "_cozystack_drbd_modprobe.failed" in when_blob, (
+        "warn task must gate on _cozystack_drbd_modprobe.failed so it "
+        "is silent on healthy hosts; got when=%r" % when
+    )
+
+
+def test_drbd_modprobe_d_cleanup_on_optout():
+    # Symmetric cleanup with modules-load.d: when the operator opts out,
+    # runs on a non-Ubuntu host, or runs on an Ubuntu release LINBIT's
+    # PPA does not publish for, /etc/modprobe.d/cozystack-drbd.conf
+    # should be removed too. Modprobe-failure case is intentionally
+    # excluded from this cleanup (param is needed once MOK is enrolled
+    # and the module loads at the next reboot).
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(plays, "Remove DRBD modprobe.d drop-in when not active")
+    f = task.get("ansible.builtin.file", {})
+    assert f.get("state") == "absent", (
+        "modprobe.d cleanup must use state=absent; got %r" % f.get("state")
+    )
+    assert f.get("path") == "/etc/modprobe.d/cozystack-drbd.conf", (
+        "modprobe.d cleanup must remove the cozystack-drbd.conf drop-in; "
+        "got %r" % f.get("path")
+    )
+    when = task.get("when")
+    when_blob = " ".join(when) if isinstance(when, list) else str(when)
+    for marker in (
+        "cozystack_enable_drbd_dkms",
+        "ansible_distribution",
+        "cozystack_drbd_supported_releases",
+    ):
+        assert marker in when_blob, (
+            "modprobe.d cleanup `when:` must reference %r so opt-out, "
+            "non-Ubuntu, and unsupported-release cases are handled. "
+            "Got: %r" % (marker, when)
+        )
+    # And must NOT trigger on modprobe failure (param is still wanted).
+    assert "_cozystack_drbd_modprobe" not in when_blob, (
+        "modprobe.d cleanup must NOT trigger on modprobe failure — the "
+        "param is still needed once the module loads after MOK enrollment. "
+        "Got: %r" % when
+    )
+
+
+def test_drbd_cleanup_removes_drop_in_when_inactive():
+    # When the toggle is off, distro is not Ubuntu, the release is not
+    # in the supported list, or modprobe failed, the modules-load
+    # drop-in must be removed (otherwise systemd-modules-load.service
+    # tries an absent module every boot). Same shape as the ZFS cleanup
+    # task.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(plays, "Remove DRBD modules-load drop-in when not active")
+    f = task.get("ansible.builtin.file", {})
+    assert f.get("state") == "absent", (
+        "cleanup task must use state=absent; got %r" % f.get("state")
+    )
+    assert f.get("path") == "/etc/modules-load.d/cozystack-drbd.conf", (
+        "cleanup must remove cozystack-drbd.conf; got %r" % f.get("path")
+    )
+    when = task.get("when")
+    when_blob = " ".join(when) if isinstance(when, list) else str(when)
+    for marker in (
+        "cozystack_enable_drbd_dkms",
+        "ansible_distribution",
+        "cozystack_drbd_supported_releases",
+        "_cozystack_drbd_modprobe",
+    ):
+        assert marker in when_blob, (
+            "cleanup `when:` must reference %r so all four inactive "
+            "cases (opt-out / non-Ubuntu / unsupported-release / "
+            "modprobe-failed) are covered. Got: %r" % (marker, when)
+        )
+
+
+def test_drbd_debian_warning_present():
+    # Debian users hit the same Secure Boot failure as Ubuntu but
+    # LINBIT does not publish a Debian PPA. A warn task must fire so
+    # Debian users know they need a manual flow rather than discover
+    # it via piraeus-operator crash-loop.
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(plays, "Warn that DRBD on Debian needs manual setup")
+    when = task.get("when") or []
+    when_blob = " ".join(when) if isinstance(when, list) else str(when)
+    assert "ansible_distribution == 'Debian'" in when_blob, (
+        "Debian-warn task must fire only on Debian; got when=%r" % when
+    )
+    assert "cozystack_enable_drbd_dkms" in when_blob, (
+        "Debian-warn task must respect the opt-out toggle; got when=%r"
+        % when
+    )
+
+
+def test_drbd_service_masked_after_install():
+    # drbd-dkms pulls drbd-utils transitively which ships a drbd.service
+    # systemd unit. Although the unit is delivered disabled, a future
+    # `systemctl enable drbd` on the host would race piraeus-operator's
+    # satellite container. Mask the unit explicitly under the same gates
+    # as the install. (The release-list gate is asserted by
+    # test_drbd_tasks_are_ubuntu_only_and_opt_outable; here we just
+    # assert the systemd action is correct.)
+    plays = _load_playbook("examples/ubuntu/prepare-ubuntu.yml")
+    task = _find_task(plays, "Mask host drbd.service")
+    s = task.get("ansible.builtin.systemd", {})
+    assert s.get("name") == "drbd.service", (
+        "mask task must target drbd.service; got %r" % s.get("name")
+    )
+    assert s.get("masked") is True, (
+        "mask task must use masked: true; got %r" % s.get("masked")
+    )
+
+
+# Documentation drift guards
+
+
+def test_readme_documents_drbd_dkms_toggle():
+    # If the toggle exists in the playbook, README must mention it.
+    # Catches doc drift when someone renames or removes the var.
+    readme_path = os.path.join(REPO_ROOT, "README.md")
+    with open(readme_path, "r", encoding="utf-8") as fh:
+        readme = fh.read()
+    for token in ("cozystack_enable_drbd_dkms", "cozystack_drbd_ppa"):
+        assert token in readme, (
+            "README.md must document the %r variable so operators "
+            "know how to opt out / override it." % token
+        )
+    # The flat "no DRBD host packages are needed" claim is no longer
+    # universally true — guard against it being silently reintroduced.
+    assert "no DRBD host packages are needed" not in readme, (
+        "README must not state 'no DRBD host packages are needed' as "
+        "an absolute — drbd-dkms is now installed on Secure Boot hosts."
+    )
+
+
+def test_readme_variables_table_lists_drbd_vars():
+    # The "Example playbook variables" table is the canonical reference
+    # operators consult — both drbd vars must appear there, not only
+    # buried inline in the prose section above.
+    readme_path = os.path.join(REPO_ROOT, "README.md")
+    with open(readme_path, "r", encoding="utf-8") as fh:
+        readme = fh.read()
+    marker = "### Example playbook variables"
+    assert marker in readme, (
+        "README must keep the '%s' anchor so this test can scope to it"
+        % marker
+    )
+    section_start = readme.index(marker)
+    # Section ends at the next ## or ### heading, whichever comes first.
+    rest = readme[section_start + len(marker):]
+    next_h2 = rest.find("\n## ")
+    next_h3 = rest.find("\n### ")
+    candidates = [i for i in (next_h2, next_h3) if i != -1]
+    section_end = section_start + len(marker) + (
+        min(candidates) if candidates else len(rest)
+    )
+    section = readme[section_start:section_end]
+    for token in ("cozystack_enable_drbd_dkms", "cozystack_drbd_ppa"):
+        assert token in section, (
+            "%r must appear in the Example playbook variables table, "
+            "not only inline elsewhere — operators look up overrides "
+            "via the table." % token
+        )
+
+
+def test_readme_known_limitations_covers_26_04_drbd():
+    # The README's Ubuntu 26.04 LTS bullet must mention the DRBD/Secure
+    # Boot gap so operators don't read 'best-effort 26.04 supported'
+    # then run into a piraeus crash-loop they can't connect to anything
+    # in the docs.
+    readme_path = os.path.join(REPO_ROOT, "README.md")
+    with open(readme_path, "r", encoding="utf-8") as fh:
+        readme = fh.read()
+    # Find the Ubuntu 26.04 LTS bullet.
+    anchor = "**Ubuntu 26.04 LTS:**"
+    assert anchor in readme, (
+        "README Known Limitations must keep the '%s' anchor" % anchor
+    )
+    # Slice from anchor to the next limitation bullet (line starting "- **").
+    start = readme.index(anchor)
+    rest = readme[start:]
+    next_bullet = rest.find("\n- **", 1)
+    end = start + (next_bullet if next_bullet != -1 else len(rest))
+    bullet = readme[start:end]
+    for token in ("drbd-dkms", "26.04", "Secure Boot"):
+        assert token in bullet, (
+            "Ubuntu 26.04 limitations bullet must mention %r so the "
+            "PPA-not-published gap is visible to operators. Got: %r"
+            % (token, bullet[:200])
+        )
+
+
+def test_claude_md_failed_when_guidance_updated():
+    # CLAUDE.md guides future contributors and AI agents; if it still
+    # says 'use failed_when: false for tolerated modprobe', the bug
+    # this PR fixes will reappear. The guidance must call out that
+    # failed_when: false rewrites .failed and direct readers to use
+    # ignore_errors when the registered var is consulted downstream.
+    claude_path = os.path.join(REPO_ROOT, "CLAUDE.md")
+    if not os.path.exists(claude_path):
+        return
+    with open(claude_path, "r", encoding="utf-8") as fh:
+        claude = fh.read()
+    assert "ignore_errors" in claude, (
+        "CLAUDE.md must mention ignore_errors as the right tool when "
+        "the registered variable is consulted downstream"
+    )
+    # Either spelling of the explanation is acceptable.
+    explained = (
+        "rewrites" in claude
+        or "ignore_errors: true" in claude
+    )
+    assert explained, (
+        "CLAUDE.md must explain WHY failed_when: false is wrong "
+        "(rewrites the registered .failed) — otherwise readers will "
+        "drop ignore_errors back to failed_when in future PRs."
+    )
+
+
+def test_claude_md_dkms_exception_documented():
+    # CLAUDE.md is the project-level guide for AI agents; if the rule
+    # there contradicts what the playbook does, agents will revert
+    # the change in future PRs. The exception must be spelled out.
+    claude_path = os.path.join(REPO_ROOT, "CLAUDE.md")
+    if not os.path.exists(claude_path):
+        return  # CLAUDE.md is optional; skip silently if absent
+    with open(claude_path, "r", encoding="utf-8") as fh:
+        claude = fh.read()
+    # Must mention the exception so the rule is no longer absolute.
+    assert "cozystack_enable_drbd_dkms" in claude or (
+        "drbd-dkms" in claude and "Secure Boot" in claude
+    ), (
+        "CLAUDE.md must document the drbd-dkms exception (Secure Boot "
+        "hosts) so the 'do NOT install' rule is no longer absolute."
+    )


### PR DESCRIPTION
## Summary

Install `drbd-dkms` from the LINBIT PPA on Ubuntu LTS hosts (jammy / noble) as part of the prepare playbook, plus configure `usermode_helper=disabled` on the drbd module and mask the host-side `drbd.service`. This unblocks non-Talos Cozystack installation on Ubuntu hosts with UEFI Secure Boot enabled, where the in-cluster DRBD module compile path used by piraeus-operator's loader fails with `Key was rejected by service` because freshly built `.ko` files are unsigned and kernel lockdown rejects them.

With drbd loaded on the host, the loader's existing host-detection logic (LINBIT/drbd `docker/entry.sh:328`) sees DRBD ≥ 9 with `usermode_helper=disabled` and exits cleanly without attempting to compile or insmod, so no operator-side change is required.

## Changes

- New variables in `examples/ubuntu/prepare-ubuntu.yml`:
  - `cozystack_enable_drbd_dkms: true` (opt-out toggle)
  - `cozystack_drbd_ppa: ppa:linbit/linbit-drbd9-stack` (override default in inventory for internal mirrors)
  - `cozystack_drbd_supported_releases: [jammy, noble]` (extend in inventory once LINBIT publishes for a new series)
- New tasks (Ubuntu only, gated on the toggle and the supported-release list): write `/etc/modprobe.d/cozystack-drbd.conf` with `options drbd usermode_helper=disabled` (BEFORE installing drbd-dkms so any package-side auto-modprobe respects the param), add the LINBIT PPA, install `drbd-dkms`, mask host `drbd.service`, modprobe drbd (tolerated via `ignore_errors: true` on Secure Boot hosts pending MOK enrollment, mirroring the existing ZFS pattern), persist via `/etc/modules-load.d/cozystack-drbd.conf` only when modprobe succeeded, plus symmetric cleanup of both drop-ins on opt-out / non-Ubuntu / unsupported-release.
- Operator-facing reminder task that fires when modprobe failed, pointing at the MOK enrollment step. Sibling warn tasks fire on Debian and on Ubuntu releases LINBIT does not publish for (Oracular 24.10, Plucky 25.04, future LTS pre-publication, etc.).
- `gnupg` added to required packages — `apt_repository` PPA flow needs `gpg` since 24.04 dropped `apt-key`, and minimal cloud images may not ship it.
- README and CLAUDE.md updated to reflect the new Secure Boot prerequisite, the new variables, and the `drbd-dkms` exception to the prior 'no DRBD host packages' rule.
- 22 structural unit tests in `tests/unit/playbooks/test_ubuntu_examples.py` covering ordering, gates, content, opt-out, supported-release list, cleanup symmetry, and documentation drift.

## Bug fix carried in alongside

The pre-existing `Load ZFS kernel module now` and `Enable multipathd service` tasks used `failed_when: false` to tolerate failures while their downstream warn / persistence tasks gated on `_var.failed`. Ansible's `failed_when: false` rewrites the registered variable's `.failed` field to `False`, silently neutering those gates. Switched to `ignore_errors: true` (preserves the module's outcome on the registered variable) and applied the same shape to the new DRBD modprobe task. CLAUDE.md was updated to call out the distinction so this does not creep back in.

## Why on Ubuntu only

LINBIT does not publish a Debian PPA, and the RHEL/SUSE flow needs a different repo plus pre-signed kmods. Worth separate PRs; this PR keeps scope tight to what can be verified end-to-end on the LINBIT-published Ubuntu LTS series. Operators on Debian / unsupported Ubuntu releases get a clear warn task pointing at the manual path.

## On Secure Boot

The MOK enrollment confirmation step (operator entering a password at the shim console on first boot after install) cannot be automated — that is by design of UEFI Secure Boot. The playbook detects the failure mode (modprobe returns `Key was rejected by service`) and emits a reminder; idempotent re-run after enrollment converges.

## Test plan

- [x] `ansible-lint` passes (production profile, 0 failures, 0 warnings)
- [x] `ansible-playbook examples/ubuntu/prepare-ubuntu.yml --syntax-check` passes
- [x] Unit tests: 29 passing (`pytest tests/unit/playbooks/test_ubuntu_examples.py`)
- [ ] Tested on a live cluster — Ubuntu 24.04 LTS with Secure Boot enabled, kernel 6.8.x, baremetal/VM with UEFI firmware. Workflow: run playbook → reboot → confirm MOK at shim → re-run playbook (expect `changed=0`) → verify `cat /sys/module/drbd/parameters/usermode_helper` → `disabled` → deploy Cozystack → confirm linstor satellite Pods reach Ready without loader retry-loop.
- [ ] Idempotency verified (second run: changed=0)

## Related

- cozystack/cozystack#2568 — original report.
- Companion docs PR in cozystack/website (will link once opened).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded DRBD prerequisites and Ubuntu 26.04 guidance, kernel-header mappings, Secure Boot/MOK notes, opt-out/override variables, and example DKMS configuration/options.
* **Changelog**
  * Added an Unreleased section summarizing DRBD-related install and gating notes and modprobe behavior changes.
* **Examples**
  * Updated Ubuntu example playbook defaults, DRBD toggles, and module-loading/failure-handling behavior.
* **Tests**
  * Added comprehensive tests validating Ubuntu DRBD/Secure Boot, modprobe handling, and release gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->