### PR TITLE
fix(prepare): disable KVM nested virtualization (CVE-2026-53359)

### DIFF
--- a/examples/rhel/prepare-rhel.yml
+++ b/examples/rhel/prepare-rhel.yml
@@ -528,6 +528,45 @@
         - cozystack_enable_kubevirt | default(true) | bool
         - (_cozystack_kvm_module | default('')) | length > 0
 
+    # The modprobe.d drop-in above only takes effect when the kvm_*
+    # module is (re)loaded. On a host where the module was already
+    # loaded at boot (the common case — the kernel autoloads it on
+    # KVM-capable CPUs) the best-effort modprobe above is a no-op and
+    # nested keeps its boot value. Read the effective state back from
+    # sysfs so a still-enabled nested is surfaced, not silently deferred
+    # to the next reboot. Only the CPU vendor's module exposes the file,
+    # so this is gated on _cozystack_kvm_module_stat and never reads a
+    # path that is absent. Read-only on purpose: we do NOT `modprobe -r`
+    # the module, which could disrupt a host whose /dev/kvm is in use.
+    - name: Read back the effective KVM nested-virt state from sysfs
+      ansible.builtin.slurp:
+        src: "/sys/module/{{ _cozystack_kvm_module }}/parameters/nested"
+      register: _cozystack_kvm_nested_state
+      failed_when: false
+      when:
+        - cozystack_enable_kubevirt | default(true) | bool
+        - cozystack_disable_kvm_nested | default(true) | bool
+        - (_cozystack_kvm_module | default('')) | length > 0
+        - _cozystack_kvm_module_stat is defined
+        - _cozystack_kvm_module_stat.stat.exists | default(false)
+
+    - name: Warn that a reboot is required to apply the KVM nested-virt mitigation
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: the CVE-2026-53359 mitigation drop-in
+          (/etc/modprobe.d/cozystack-kvm-nested.conf) is written, but
+          {{ _cozystack_kvm_module }} is already loaded with nested
+          virtualization ENABLED. A running kvm module cannot be
+          re-parameterised while /dev/kvm may be in use, so the mitigation
+          is NOT active yet. Reboot the host -- or, when no VMs are
+          running, `modprobe -r {{ _cozystack_kvm_module }} && modprobe
+          {{ _cozystack_kvm_module }}` -- to apply nested=0.
+      when:
+        - cozystack_enable_kubevirt | default(true) | bool
+        - cozystack_disable_kvm_nested | default(true) | bool
+        - _cozystack_kvm_nested_state.content is defined
+        - (_cozystack_kvm_nested_state.content | b64decode | trim) in ['Y', '1']
+
     - name: Persist KubeVirt kernel modules for boot
       ansible.builtin.copy:
         dest: /etc/modules-load.d/cozystack-kubevirt.conf

--- a/examples/rhel/prepare-rhel.yml
+++ b/examples/rhel/prepare-rhel.yml
@@ -470,6 +470,33 @@
              else '' }}
       when: cozystack_enable_kubevirt | default(true) | bool
 
+    # CVE-2026-53359 (Januscape): the KVM guest-to-host escape requires nested
+    # virtualization exposed to the guest. Cozystack VMs never need nested virt,
+    # so disable it on the host. Written BEFORE the kvm_* module is loaded below
+    # so the parameter takes effect on load. On a host where kvm_intel/kvm_amd is
+    # already loaded, a reboot -- or `modprobe -r kvm_intel kvm_amd && modprobe
+    # <vendor-module>` -- is required to apply. Set cozystack_disable_kvm_nested=false
+    # to opt out.
+    - name: Disable KVM nested virtualization (CVE-2026-53359 mitigation)
+      ansible.builtin.copy:
+        dest: /etc/modprobe.d/cozystack-kvm-nested.conf
+        mode: "0644"
+        content: |
+          # CVE-2026-53359: disable KVM nested virtualization (guest-to-host escape mitigation)
+          options kvm_intel nested=0
+          options kvm_amd nested=0
+      when:
+        - cozystack_enable_kubevirt | default(true) | bool
+        - cozystack_disable_kvm_nested | default(true) | bool
+
+    - name: Remove KVM nested-virt drop-in when not active
+      ansible.builtin.file:
+        path: /etc/modprobe.d/cozystack-kvm-nested.conf
+        state: absent
+      when: >-
+        not (cozystack_enable_kubevirt | default(true) | bool) or
+        not (cozystack_disable_kvm_nested | default(true) | bool)
+
     # Required KubeVirt modules must load; if vhost_net or tun is unavailable
     # (custom/stripped kernel) the playbook fails here rather than proceed.
     - name: Load required KubeVirt kernel modules now

--- a/examples/suse/prepare-suse.yml
+++ b/examples/suse/prepare-suse.yml
@@ -502,6 +502,45 @@
         - cozystack_enable_kubevirt | default(true) | bool
         - (_cozystack_kvm_module | default('')) | length > 0
 
+    # The modprobe.d drop-in above only takes effect when the kvm_*
+    # module is (re)loaded. On a host where the module was already
+    # loaded at boot (the common case — the kernel autoloads it on
+    # KVM-capable CPUs) the best-effort modprobe above is a no-op and
+    # nested keeps its boot value. Read the effective state back from
+    # sysfs so a still-enabled nested is surfaced, not silently deferred
+    # to the next reboot. Only the CPU vendor's module exposes the file,
+    # so this is gated on _cozystack_kvm_module_stat and never reads a
+    # path that is absent. Read-only on purpose: we do NOT `modprobe -r`
+    # the module, which could disrupt a host whose /dev/kvm is in use.
+    - name: Read back the effective KVM nested-virt state from sysfs
+      ansible.builtin.slurp:
+        src: "/sys/module/{{ _cozystack_kvm_module }}/parameters/nested"
+      register: _cozystack_kvm_nested_state
+      failed_when: false
+      when:
+        - cozystack_enable_kubevirt | default(true) | bool
+        - cozystack_disable_kvm_nested | default(true) | bool
+        - (_cozystack_kvm_module | default('')) | length > 0
+        - _cozystack_kvm_module_stat is defined
+        - _cozystack_kvm_module_stat.stat.exists | default(false)
+
+    - name: Warn that a reboot is required to apply the KVM nested-virt mitigation
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: the CVE-2026-53359 mitigation drop-in
+          (/etc/modprobe.d/cozystack-kvm-nested.conf) is written, but
+          {{ _cozystack_kvm_module }} is already loaded with nested
+          virtualization ENABLED. A running kvm module cannot be
+          re-parameterised while /dev/kvm may be in use, so the mitigation
+          is NOT active yet. Reboot the host -- or, when no VMs are
+          running, `modprobe -r {{ _cozystack_kvm_module }} && modprobe
+          {{ _cozystack_kvm_module }}` -- to apply nested=0.
+      when:
+        - cozystack_enable_kubevirt | default(true) | bool
+        - cozystack_disable_kvm_nested | default(true) | bool
+        - _cozystack_kvm_nested_state.content is defined
+        - (_cozystack_kvm_nested_state.content | b64decode | trim) in ['Y', '1']
+
     - name: Persist KubeVirt kernel modules for boot
       ansible.builtin.copy:
         dest: /etc/modules-load.d/cozystack-kubevirt.conf

--- a/examples/suse/prepare-suse.yml
+++ b/examples/suse/prepare-suse.yml
@@ -444,6 +444,33 @@
              else '' }}
       when: cozystack_enable_kubevirt | default(true) | bool
 
+    # CVE-2026-53359 (Januscape): the KVM guest-to-host escape requires nested
+    # virtualization exposed to the guest. Cozystack VMs never need nested virt,
+    # so disable it on the host. Written BEFORE the kvm_* module is loaded below
+    # so the parameter takes effect on load. On a host where kvm_intel/kvm_amd is
+    # already loaded, a reboot -- or `modprobe -r kvm_intel kvm_amd && modprobe
+    # <vendor-module>` -- is required to apply. Set cozystack_disable_kvm_nested=false
+    # to opt out.
+    - name: Disable KVM nested virtualization (CVE-2026-53359 mitigation)
+      ansible.builtin.copy:
+        dest: /etc/modprobe.d/cozystack-kvm-nested.conf
+        mode: "0644"
+        content: |
+          # CVE-2026-53359: disable KVM nested virtualization (guest-to-host escape mitigation)
+          options kvm_intel nested=0
+          options kvm_amd nested=0
+      when:
+        - cozystack_enable_kubevirt | default(true) | bool
+        - cozystack_disable_kvm_nested | default(true) | bool
+
+    - name: Remove KVM nested-virt drop-in when not active
+      ansible.builtin.file:
+        path: /etc/modprobe.d/cozystack-kvm-nested.conf
+        state: absent
+      when: >-
+        not (cozystack_enable_kubevirt | default(true) | bool) or
+        not (cozystack_disable_kvm_nested | default(true) | bool)
+
     # Required KubeVirt modules must load; if vhost_net or tun is unavailable
     # (custom/stripped kernel) the playbook fails here rather than proceed.
     - name: Load required KubeVirt kernel modules now

--- a/examples/ubuntu/prepare-ubuntu.yml
+++ b/examples/ubuntu/prepare-ubuntu.yml
@@ -678,6 +678,33 @@
              else '' }}
       when: cozystack_enable_kubevirt | default(true) | bool
 
+    # CVE-2026-53359 (Januscape): the KVM guest-to-host escape requires nested
+    # virtualization exposed to the guest. Cozystack VMs never need nested virt,
+    # so disable it on the host. Written BEFORE the kvm_* module is loaded below
+    # so the parameter takes effect on load (mirrors the DRBD modprobe.d ordering
+    # above). On a host where kvm_intel/kvm_amd is already loaded, a reboot -- or
+    # `modprobe -r kvm_intel kvm_amd && modprobe <vendor-module>` -- is required
+    # to apply. Set cozystack_disable_kvm_nested=false to opt out.
+    - name: Disable KVM nested virtualization (CVE-2026-53359 mitigation)
+      ansible.builtin.copy:
+        dest: /etc/modprobe.d/cozystack-kvm-nested.conf
+        mode: "0644"
+        content: |
+          # CVE-2026-53359: disable KVM nested virtualization (guest-to-host escape mitigation)
+          options kvm_intel nested=0
+          options kvm_amd nested=0
+      when:
+        - cozystack_enable_kubevirt | default(true) | bool
+        - cozystack_disable_kvm_nested | default(true) | bool
+
+    - name: Remove KVM nested-virt drop-in when not active
+      ansible.builtin.file:
+        path: /etc/modprobe.d/cozystack-kvm-nested.conf
+        state: absent
+      when: >-
+        not (cozystack_enable_kubevirt | default(true) | bool) or
+        not (cozystack_disable_kvm_nested | default(true) | bool)
+
     # Required KubeVirt modules must load; if vhost_net or tun is unavailable
     # (custom/stripped kernel) the playbook fails here rather than proceed.
     - name: Load required KubeVirt kernel modules now

--- a/examples/ubuntu/prepare-ubuntu.yml
+++ b/examples/ubuntu/prepare-ubuntu.yml
@@ -736,6 +736,45 @@
         - cozystack_enable_kubevirt | default(true) | bool
         - (_cozystack_kvm_module | default('')) | length > 0
 
+    # The modprobe.d drop-in above only takes effect when the kvm_*
+    # module is (re)loaded. On a host where the module was already
+    # loaded at boot (the common case — the kernel autoloads it on
+    # KVM-capable CPUs) the best-effort modprobe above is a no-op and
+    # nested keeps its boot value. Read the effective state back from
+    # sysfs so a still-enabled nested is surfaced, not silently deferred
+    # to the next reboot. Only the CPU vendor's module exposes the file,
+    # so this is gated on _cozystack_kvm_module_stat and never reads a
+    # path that is absent. Read-only on purpose: we do NOT `modprobe -r`
+    # the module, which could disrupt a host whose /dev/kvm is in use.
+    - name: Read back the effective KVM nested-virt state from sysfs
+      ansible.builtin.slurp:
+        src: "/sys/module/{{ _cozystack_kvm_module }}/parameters/nested"
+      register: _cozystack_kvm_nested_state
+      failed_when: false
+      when:
+        - cozystack_enable_kubevirt | default(true) | bool
+        - cozystack_disable_kvm_nested | default(true) | bool
+        - (_cozystack_kvm_module | default('')) | length > 0
+        - _cozystack_kvm_module_stat is defined
+        - _cozystack_kvm_module_stat.stat.exists | default(false)
+
+    - name: Warn that a reboot is required to apply the KVM nested-virt mitigation
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: the CVE-2026-53359 mitigation drop-in
+          (/etc/modprobe.d/cozystack-kvm-nested.conf) is written, but
+          {{ _cozystack_kvm_module }} is already loaded with nested
+          virtualization ENABLED. A running kvm module cannot be
+          re-parameterised while /dev/kvm may be in use, so the mitigation
+          is NOT active yet. Reboot the host -- or, when no VMs are
+          running, `modprobe -r {{ _cozystack_kvm_module }} && modprobe
+          {{ _cozystack_kvm_module }}` -- to apply nested=0.
+      when:
+        - cozystack_enable_kubevirt | default(true) | bool
+        - cozystack_disable_kvm_nested | default(true) | bool
+        - _cozystack_kvm_nested_state.content is defined
+        - (_cozystack_kvm_nested_state.content | b64decode | trim) in ['Y', '1']
+
     - name: Persist KubeVirt kernel modules for boot
       ansible.builtin.copy:
         dest: /etc/modules-load.d/cozystack-kubevirt.conf


### PR DESCRIPTION
## Summary

Disables KVM nested virtualization on generic (non-Talos) Ubuntu/RHEL/SUSE hosts prepared for Cozystack, to mitigate **CVE-2026-53359** ("Januscape"), a guest-to-host escape in the Linux KVM/x86 shadow MMU (a use-after-free in `kvm_mmu_get_child_sp()` from shadow-page role confusion).

The vulnerable code path is only reachable when a guest is allowed to use nested virtualization; disabling it on the host removes the attack surface regardless of the node kernel patch level. Fixed upstream in `81ccda30b4e8` / stable 6.12.95, 6.6.144, 6.1.177, 6.18.38, 7.1.3 (2026-07-04).

## Changes

- Ship an `/etc/modprobe.d/cozystack-kvm-nested.conf` drop-in (`options kvm_intel nested=0` / `options kvm_amd nested=0`) in `examples/{ubuntu,rhel,suse}/prepare-*.yml`, written before the `kvm_*` module is loaded (mirrors the existing DRBD modprobe.d ordering). Both options are set so one drop-in covers Intel and AMD.
- Gated by a new `cozystack_disable_kvm_nested` variable (default `true`); a paired cleanup task removes the drop-in when opted out or when KubeVirt is disabled.
- On a host where `kvm_intel`/`kvm_amd` is already loaded, a reboot (or module reload) is required for the change to take effect.

Part of a coordinated set of PRs (see Related PRs below).

## Test plan

- [ ] `ansible-lint` passes
- [ ] `ansible-test sanity` passes
- [ ] Tested on a live cluster (describe environment)
- [ ] Idempotency verified (second run: changed=0)

<sub>Verified locally: `ansible-playbook --syntax-check` passes on all three playbooks. `ansible-lint` / live / idempotency not yet run — left for CI / reviewer.</sub>

## Related PRs

Coordinated **CVE-2026-53359** (Januscape) nested-virtualization mitigation across Cozystack repos:

- cozystack/cozystack#3234 — E2E Talos machine-config
- cozystack/talm#224 — Talos `cozystack`/`generic` presets (canonical source)
- cozystack/website#602 — install docs (all versions)
- cozystack/ccp#17 — Talos bootstrap/upgrade skills (prescribe + verify, survives upgrades)
- cozystack/ansible-cozystack#60 — generic Ubuntu/RHEL/SUSE hosts (modprobe.d)
