### PR TITLE
fix(prepare): keep KVM nested virtualization enabled

### DIFF
--- a/examples/rhel/prepare-rhel.yml
+++ b/examples/rhel/prepare-rhel.yml
@@ -470,33 +470,6 @@
              else '' }}
       when: cozystack_enable_kubevirt | default(true) | bool
 
-    # CVE-2026-53359 (Januscape): the KVM guest-to-host escape requires nested
-    # virtualization exposed to the guest. Cozystack VMs never need nested virt,
-    # so disable it on the host. Written BEFORE the kvm_* module is loaded below
-    # so the parameter takes effect on load. On a host where kvm_intel/kvm_amd is
-    # already loaded, a reboot -- or `modprobe -r kvm_intel kvm_amd && modprobe
-    # <vendor-module>` -- is required to apply. Set cozystack_disable_kvm_nested=false
-    # to opt out.
-    - name: Disable KVM nested virtualization (CVE-2026-53359 mitigation)
-      ansible.builtin.copy:
-        dest: /etc/modprobe.d/cozystack-kvm-nested.conf
-        mode: "0644"
-        content: |
-          # CVE-2026-53359: disable KVM nested virtualization (guest-to-host escape mitigation)
-          options kvm_intel nested=0
-          options kvm_amd nested=0
-      when:
-        - cozystack_enable_kubevirt | default(true) | bool
-        - cozystack_disable_kvm_nested | default(true) | bool
-
-    - name: Remove KVM nested-virt drop-in when not active
-      ansible.builtin.file:
-        path: /etc/modprobe.d/cozystack-kvm-nested.conf
-        state: absent
-      when: >-
-        not (cozystack_enable_kubevirt | default(true) | bool) or
-        not (cozystack_disable_kvm_nested | default(true) | bool)
-
     # Required KubeVirt modules must load; if vhost_net or tun is unavailable
     # (custom/stripped kernel) the playbook fails here rather than proceed.
     - name: Load required KubeVirt kernel modules now
@@ -527,45 +500,6 @@
       when:
         - cozystack_enable_kubevirt | default(true) | bool
         - (_cozystack_kvm_module | default('')) | length > 0
-
-    # The modprobe.d drop-in above only takes effect when the kvm_*
-    # module is (re)loaded. On a host where the module was already
-    # loaded at boot (the common case — the kernel autoloads it on
-    # KVM-capable CPUs) the best-effort modprobe above is a no-op and
-    # nested keeps its boot value. Read the effective state back from
-    # sysfs so a still-enabled nested is surfaced, not silently deferred
-    # to the next reboot. Only the CPU vendor's module exposes the file,
-    # so this is gated on _cozystack_kvm_module_stat and never reads a
-    # path that is absent. Read-only on purpose: we do NOT `modprobe -r`
-    # the module, which could disrupt a host whose /dev/kvm is in use.
-    - name: Read back the effective KVM nested-virt state from sysfs
-      ansible.builtin.slurp:
-        src: "/sys/module/{{ _cozystack_kvm_module }}/parameters/nested"
-      register: _cozystack_kvm_nested_state
-      failed_when: false
-      when:
-        - cozystack_enable_kubevirt | default(true) | bool
-        - cozystack_disable_kvm_nested | default(true) | bool
-        - (_cozystack_kvm_module | default('')) | length > 0
-        - _cozystack_kvm_module_stat is defined
-        - _cozystack_kvm_module_stat.stat.exists | default(false)
-
-    - name: Warn that a reboot is required to apply the KVM nested-virt mitigation
-      ansible.builtin.debug:
-        msg: >-
-          WARNING: the CVE-2026-53359 mitigation drop-in
-          (/etc/modprobe.d/cozystack-kvm-nested.conf) is written, but
-          {{ _cozystack_kvm_module }} is already loaded with nested
-          virtualization ENABLED. A running kvm module cannot be
-          re-parameterised while /dev/kvm may be in use, so the mitigation
-          is NOT active yet. Reboot the host -- or, when no VMs are
-          running, `modprobe -r {{ _cozystack_kvm_module }} && modprobe
-          {{ _cozystack_kvm_module }}` -- to apply nested=0.
-      when:
-        - cozystack_enable_kubevirt | default(true) | bool
-        - cozystack_disable_kvm_nested | default(true) | bool
-        - _cozystack_kvm_nested_state.content is defined
-        - (_cozystack_kvm_nested_state.content | b64decode | trim) in ['Y', '1']
 
     - name: Persist KubeVirt kernel modules for boot
       ansible.builtin.copy:

--- a/examples/suse/prepare-suse.yml
+++ b/examples/suse/prepare-suse.yml
@@ -444,33 +444,6 @@
              else '' }}
       when: cozystack_enable_kubevirt | default(true) | bool
 
-    # CVE-2026-53359 (Januscape): the KVM guest-to-host escape requires nested
-    # virtualization exposed to the guest. Cozystack VMs never need nested virt,
-    # so disable it on the host. Written BEFORE the kvm_* module is loaded below
-    # so the parameter takes effect on load. On a host where kvm_intel/kvm_amd is
-    # already loaded, a reboot -- or `modprobe -r kvm_intel kvm_amd && modprobe
-    # <vendor-module>` -- is required to apply. Set cozystack_disable_kvm_nested=false
-    # to opt out.
-    - name: Disable KVM nested virtualization (CVE-2026-53359 mitigation)
-      ansible.builtin.copy:
-        dest: /etc/modprobe.d/cozystack-kvm-nested.conf
-        mode: "0644"
-        content: |
-          # CVE-2026-53359: disable KVM nested virtualization (guest-to-host escape mitigation)
-          options kvm_intel nested=0
-          options kvm_amd nested=0
-      when:
-        - cozystack_enable_kubevirt | default(true) | bool
-        - cozystack_disable_kvm_nested | default(true) | bool
-
-    - name: Remove KVM nested-virt drop-in when not active
-      ansible.builtin.file:
-        path: /etc/modprobe.d/cozystack-kvm-nested.conf
-        state: absent
-      when: >-
-        not (cozystack_enable_kubevirt | default(true) | bool) or
-        not (cozystack_disable_kvm_nested | default(true) | bool)
-
     # Required KubeVirt modules must load; if vhost_net or tun is unavailable
     # (custom/stripped kernel) the playbook fails here rather than proceed.
     - name: Load required KubeVirt kernel modules now
@@ -501,45 +474,6 @@
       when:
         - cozystack_enable_kubevirt | default(true) | bool
         - (_cozystack_kvm_module | default('')) | length > 0
-
-    # The modprobe.d drop-in above only takes effect when the kvm_*
-    # module is (re)loaded. On a host where the module was already
-    # loaded at boot (the common case — the kernel autoloads it on
-    # KVM-capable CPUs) the best-effort modprobe above is a no-op and
-    # nested keeps its boot value. Read the effective state back from
-    # sysfs so a still-enabled nested is surfaced, not silently deferred
-    # to the next reboot. Only the CPU vendor's module exposes the file,
-    # so this is gated on _cozystack_kvm_module_stat and never reads a
-    # path that is absent. Read-only on purpose: we do NOT `modprobe -r`
-    # the module, which could disrupt a host whose /dev/kvm is in use.
-    - name: Read back the effective KVM nested-virt state from sysfs
-      ansible.builtin.slurp:
-        src: "/sys/module/{{ _cozystack_kvm_module }}/parameters/nested"
-      register: _cozystack_kvm_nested_state
-      failed_when: false
-      when:
-        - cozystack_enable_kubevirt | default(true) | bool
-        - cozystack_disable_kvm_nested | default(true) | bool
-        - (_cozystack_kvm_module | default('')) | length > 0
-        - _cozystack_kvm_module_stat is defined
-        - _cozystack_kvm_module_stat.stat.exists | default(false)
-
-    - name: Warn that a reboot is required to apply the KVM nested-virt mitigation
-      ansible.builtin.debug:
-        msg: >-
-          WARNING: the CVE-2026-53359 mitigation drop-in
-          (/etc/modprobe.d/cozystack-kvm-nested.conf) is written, but
-          {{ _cozystack_kvm_module }} is already loaded with nested
-          virtualization ENABLED. A running kvm module cannot be
-          re-parameterised while /dev/kvm may be in use, so the mitigation
-          is NOT active yet. Reboot the host -- or, when no VMs are
-          running, `modprobe -r {{ _cozystack_kvm_module }} && modprobe
-          {{ _cozystack_kvm_module }}` -- to apply nested=0.
-      when:
-        - cozystack_enable_kubevirt | default(true) | bool
-        - cozystack_disable_kvm_nested | default(true) | bool
-        - _cozystack_kvm_nested_state.content is defined
-        - (_cozystack_kvm_nested_state.content | b64decode | trim) in ['Y', '1']
 
     - name: Persist KubeVirt kernel modules for boot
       ansible.builtin.copy:

--- a/examples/ubuntu/prepare-ubuntu.yml
+++ b/examples/ubuntu/prepare-ubuntu.yml
@@ -678,33 +678,6 @@
              else '' }}
       when: cozystack_enable_kubevirt | default(true) | bool
 
-    # CVE-2026-53359 (Januscape): the KVM guest-to-host escape requires nested
-    # virtualization exposed to the guest. Cozystack VMs never need nested virt,
-    # so disable it on the host. Written BEFORE the kvm_* module is loaded below
-    # so the parameter takes effect on load (mirrors the DRBD modprobe.d ordering
-    # above). On a host where kvm_intel/kvm_amd is already loaded, a reboot -- or
-    # `modprobe -r kvm_intel kvm_amd && modprobe <vendor-module>` -- is required
-    # to apply. Set cozystack_disable_kvm_nested=false to opt out.
-    - name: Disable KVM nested virtualization (CVE-2026-53359 mitigation)
-      ansible.builtin.copy:
-        dest: /etc/modprobe.d/cozystack-kvm-nested.conf
-        mode: "0644"
-        content: |
-          # CVE-2026-53359: disable KVM nested virtualization (guest-to-host escape mitigation)
-          options kvm_intel nested=0
-          options kvm_amd nested=0
-      when:
-        - cozystack_enable_kubevirt | default(true) | bool
-        - cozystack_disable_kvm_nested | default(true) | bool
-
-    - name: Remove KVM nested-virt drop-in when not active
-      ansible.builtin.file:
-        path: /etc/modprobe.d/cozystack-kvm-nested.conf
-        state: absent
-      when: >-
-        not (cozystack_enable_kubevirt | default(true) | bool) or
-        not (cozystack_disable_kvm_nested | default(true) | bool)
-
     # Required KubeVirt modules must load; if vhost_net or tun is unavailable
     # (custom/stripped kernel) the playbook fails here rather than proceed.
     - name: Load required KubeVirt kernel modules now
@@ -735,45 +708,6 @@
       when:
         - cozystack_enable_kubevirt | default(true) | bool
         - (_cozystack_kvm_module | default('')) | length > 0
-
-    # The modprobe.d drop-in above only takes effect when the kvm_*
-    # module is (re)loaded. On a host where the module was already
-    # loaded at boot (the common case — the kernel autoloads it on
-    # KVM-capable CPUs) the best-effort modprobe above is a no-op and
-    # nested keeps its boot value. Read the effective state back from
-    # sysfs so a still-enabled nested is surfaced, not silently deferred
-    # to the next reboot. Only the CPU vendor's module exposes the file,
-    # so this is gated on _cozystack_kvm_module_stat and never reads a
-    # path that is absent. Read-only on purpose: we do NOT `modprobe -r`
-    # the module, which could disrupt a host whose /dev/kvm is in use.
-    - name: Read back the effective KVM nested-virt state from sysfs
-      ansible.builtin.slurp:
-        src: "/sys/module/{{ _cozystack_kvm_module }}/parameters/nested"
-      register: _cozystack_kvm_nested_state
-      failed_when: false
-      when:
-        - cozystack_enable_kubevirt | default(true) | bool
-        - cozystack_disable_kvm_nested | default(true) | bool
-        - (_cozystack_kvm_module | default('')) | length > 0
-        - _cozystack_kvm_module_stat is defined
-        - _cozystack_kvm_module_stat.stat.exists | default(false)
-
-    - name: Warn that a reboot is required to apply the KVM nested-virt mitigation
-      ansible.builtin.debug:
-        msg: >-
-          WARNING: the CVE-2026-53359 mitigation drop-in
-          (/etc/modprobe.d/cozystack-kvm-nested.conf) is written, but
-          {{ _cozystack_kvm_module }} is already loaded with nested
-          virtualization ENABLED. A running kvm module cannot be
-          re-parameterised while /dev/kvm may be in use, so the mitigation
-          is NOT active yet. Reboot the host -- or, when no VMs are
-          running, `modprobe -r {{ _cozystack_kvm_module }} && modprobe
-          {{ _cozystack_kvm_module }}` -- to apply nested=0.
-      when:
-        - cozystack_enable_kubevirt | default(true) | bool
-        - cozystack_disable_kvm_nested | default(true) | bool
-        - _cozystack_kvm_nested_state.content is defined
-        - (_cozystack_kvm_nested_state.content | b64decode | trim) in ['Y', '1']
 
     - name: Persist KubeVirt kernel modules for boot
       ansible.builtin.copy:


### PR DESCRIPTION
## Summary

Restores KVM nested virtualization on hosts prepared by the example playbooks. Today the playbooks write `/etc/modprobe.d/cozystack-kvm-nested.conf` with `options kvm_intel nested=0` and `options kvm_amd nested=0` whenever KubeVirt is enabled, so every generic-Linux node loses nested virtualization by default.

The mechanism is not the problem. On a general-purpose Linux distribution `kvm_intel` and `kvm_amd` are loadable modules, so a `modprobe.d` drop-in genuinely takes effect when the module loads. The default is the problem. Nested virtualization is a capability real workloads depend on — running a hypervisor, a nested Kubernetes cluster, or an OS installer inside a VM — and turning it off for everyone withdraws that capability from every host the playbooks touch. The opt-out variable only helps operators who already know the drop-in exists.

CVE-2026-53359 and the closely related CVE-2026-46113 are use-after-free bugs in the KVM x86 shadow-paging MMU, and both are fixed in the kernel. A kernel needs both upstream patches to be fully covered. The fixes shipped in the stable kernels released on 2026-07-04 — 7.1.3, 6.18.38, 6.12.95, 6.6.144, 6.1.177, 5.15.211, 5.10.260 — and in every later release on those branches, which are cumulative. Distributions maintaining their own backported kernels carry the same fixes in their patched packages. Running a current kernel is the remedy; taking a supported feature away from every user is not.

## Changes

- Drop the `/etc/modprobe.d/cozystack-kvm-nested.conf` drop-in and its companion removal task from `examples/rhel/prepare-rhel.yml`, `examples/suse/prepare-suse.yml`, and `examples/ubuntu/prepare-ubuntu.yml`.
- Drop the sysfs read-back and the reboot-required warning that existed only to report on the mitigation.
- Drop the `cozystack_disable_kvm_nested` variable. Nested virtualization is left at the kernel's own default.

## Test plan

- [x] `ansible-lint` passes
- [x] `ansible-test sanity` passes
- [ ] Tested on a live cluster (describe environment)
- [ ] Idempotency verified (second run: changed=0)

The two unchecked boxes need a live host. This change only deletes tasks, returning the three playbooks to a byte-identical copy of their last released state, so the remaining coverage is the lint, sanity, and unit suites plus the existing E2E job.
